### PR TITLE
Handle empty runs better

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "cypress": "^4.2.0",
-    "happo.io": "^5.2.0-rc.2",
+    "happo.io": "^5.4.0",
     "next": "^9.3.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/task.js
+++ b/task.js
@@ -95,6 +95,10 @@ module.exports = {
     if (!isEnabled) {
       return null;
     }
+    if (!snapshots.length) {
+      console.log(`[HAPPO] No snapshots were recorded. Ignoring.`);
+      return null;
+    }
     await downloadCSSContent(allCssBlocks, baseUrl);
     const allUrls = new Set([...snapshotAssetUrls]);
     allCssBlocks.forEach(block => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,10 +3435,10 @@ gzip-size@5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-happo.io@^5.2.0-rc.2:
-  version "5.2.0-rc.2"
-  resolved "https://registry.npmjs.org/happo.io/-/happo.io-5.2.0-rc.2.tgz#29dfdf85f7007a620a1ee5c0d3c501253d927226"
-  integrity sha512-NsasWOoNzmibePWJQtS8xHqkIjS7HhGo+LejLp2mPi+bWdVvEgnzwnoQLPSKtyU9M4aJqPOiFi3mLggo5ldT6w==
+happo.io@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.npmjs.org/happo.io/-/happo.io-5.4.0.tgz#e260aeddc3f5e2251234f07e4e5652f38cef4cf9"
+  integrity sha512-O+JhXhc/I9UOawmjszVZ8Ia1K1mx28eO+sBbcfIB2CKVLg0fvk9pyD7Jj8ZCpa1BhnAwCwor8lwF3ml6LJATTw==
   dependencies:
     archiver "^3.0.0"
     async-retry "^1.3.1"


### PR DESCRIPTION
Don't create happo reports for empty runs

In case we're not recording any happoScreenshots during a test run, it
makes no sense to have Happo process things and create a report.

This might fix an issue we're seeing at Lightstep where a POST to the
happo.io API fails with a `missing requestIds` message.