### PR TITLE
Add happo-cypress wrapper command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@1.1.6
+  cypress: cypress-io/cypress@1.23.0
 jobs:
   build-and-test:
     executor:
@@ -12,6 +13,11 @@ jobs:
             - run: yarn install
             - run: yarn lint
 workflows:
-    build-and-test:
-      jobs:
-        - build-and-test
+  build-and-test:
+    jobs:
+      - build-and-test
+  cypress:
+    jobs:
+      - cypress/run:
+          yarn: true
+          start: yarn dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ workflows:
       - cypress/run:
           yarn: true
           start: yarn dev
-          command-prefix: node bin/happo-cypress.js --
+          command: node bin/happo-cypress.js -- yarn cypress run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,3 +21,4 @@ workflows:
       - cypress/run:
           yarn: true
           start: yarn dev
+          command-prefix: node bin/happo-cypress.js --

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+cypress/videos

--- a/bin/happo-cypress.js
+++ b/bin/happo-cypress.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const http = require('http');
 const { spawn } = require('child_process');
 

--- a/bin/happo-cypress.js
+++ b/bin/happo-cypress.js
@@ -1,0 +1,123 @@
+const http = require('http');
+const { spawn } = require('child_process');
+
+const makeRequest = require('happo.io/build/makeRequest').default;
+const compareReports = require('happo.io/build/commands/compareReports')
+  .default;
+
+const loadHappoConfig = require('../src/loadHappoConfig');
+const resolveEnvironment = require('../src/resolveEnvironment');
+
+function failWithMissingCommand() {
+  console.error('Missing command. Usage: `happo-cypress -- cypress run`');
+  process.exit(1);
+}
+
+const allRequestIds = new Set();
+
+function requestHandler(req, res) {
+  req.on('data', chunk => {
+    chunk
+      .toString()
+      .split('\n')
+      .filter(Boolean)
+      .forEach(requestId => allRequestIds.add(parseInt(requestId, 10)));
+  });
+  req.on('end', () => {
+    res.writeHead(200);
+    res.end('');
+  });
+}
+
+async function finalizeHappoReport() {
+  const happoConfig = await loadHappoConfig();
+  if (!happoConfig) {
+    return;
+  }
+
+  if (!allRequestIds.size) {
+    console.log(`[HAPPO] No snapshots were recorded. Ignoring.`);
+    return;
+  }
+
+  const { beforeSha, afterSha, link, message } = resolveEnvironment();
+  const reportResult = await makeRequest(
+    {
+      url: `${happoConfig.endpoint}/api/async-reports/${afterSha}`,
+      method: 'POST',
+      json: true,
+      body: {
+        requestIds: [...allRequestIds],
+        project: happoConfig.project,
+      },
+    },
+    { ...happoConfig, maxTries: 3 },
+  );
+
+  if (beforeSha) {
+    const jobResult = await makeRequest(
+      {
+        url: `${happoConfig.endpoint}/api/jobs/${beforeSha}/${afterSha}`,
+        method: 'POST',
+        json: true,
+        body: {
+          project: happoConfig.project,
+          link,
+          message,
+        },
+      },
+      { ...happoConfig, maxTries: 3 },
+    );
+    if (beforeSha !== afterSha) {
+      await compareReports(beforeSha, afterSha, happoConfig, {
+        link,
+        message,
+        isAsync: true,
+      });
+    }
+    console.log(`[HAPPO] ${jobResult.url}`);
+  } else {
+    console.log(`[HAPPO] ${reportResult.url}`);
+  }
+}
+
+function startServer(port = 5338) {
+  const server = http.createServer(requestHandler);
+  return new Promise(resolve => {
+    server.listen(5338, () => resolve(port));
+  });
+}
+
+async function init(argv) {
+  const dashdashIndex = argv.indexOf('--');
+  if (dashdashIndex === -1) {
+    failWithMissingCommand();
+  }
+
+  const commandParts = argv.slice(argv.indexOf('--') + 1);
+
+  if (!commandParts.length) {
+    failWithMissingCommand();
+  }
+  const serverPort = await startServer();
+  console.log(`[HAPPO] Listening on port ${serverPort}`);
+
+  const child = spawn(commandParts[0], commandParts.slice(1), {
+    stdio: 'inherit',
+  });
+
+  child.on('error', e => {
+    console.error(e);
+    process.exit(1);
+  });
+
+  child.on('close', async code => {
+    if (code === 0) {
+      await finalizeHappoReport();
+    }
+
+    process.exit(code);
+  });
+}
+
+init(process.argv);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:happo/happo-cypress.git",
   "author": "Henric Trotzig <henric.trotzig@happo.io>",
   "license": "MIT",
+  "bin": {
+    "happo-cypress": "./bin/happo-cypress.js"
+  },
   "scripts": {
     "dev": "next --port 7654",
     "build": "next build",

--- a/src/loadHappoConfig.js
+++ b/src/loadHappoConfig.js
@@ -1,0 +1,17 @@
+const loadUserConfig = require('happo.io/build/loadUserConfig').default;
+
+module.exports = async function loadHappoConfig() {
+  try {
+    const happoConfig = await loadUserConfig('./.happo.js');
+    return happoConfig;
+  } catch (e) {
+    if (/You need an.*apiKey/.test(e.message)) {
+      console.warn(
+        "[HAPPO] Happo is disabled since we couldn't find an `apiKey` and/or `apiSecret`",
+      );
+      return;
+    } else {
+      throw e;
+    }
+  }
+}

--- a/task.js
+++ b/task.js
@@ -5,6 +5,8 @@ const findCSSAssetUrls = require('./src/findCSSAssetUrls');
 const loadHappoConfig = require('./src/loadHappoConfig');
 const makeAbsolute = require('./src/makeAbsolute');
 
+const { HAPPO_CYPRESS_PORT = 5338 } = process.env;
+
 let snapshots;
 let allCssBlocks;
 let snapshotAssetUrls;
@@ -108,7 +110,7 @@ module.exports = {
         allRequestIds.push(...requestIds);
       }),
     );
-    const fetchRes = await nodeFetch('http://localhost:5338/', {
+    const fetchRes = await nodeFetch(`http://localhost:${HAPPO_CYPRESS_PORT}/`, {
       method: 'POST',
       body: allRequestIds.join('\n'),
     });

--- a/task.js
+++ b/task.js
@@ -1,21 +1,16 @@
 const nodeFetch = require('node-fetch');
-const loadUserConfig = require('happo.io/build/loadUserConfig').default;
-const makeRequest = require('happo.io/build/makeRequest').default;
-const compareReports = require('happo.io/build/commands/compareReports')
-  .default;
 
 const createAssetPackage = require('./src/createAssetPackage');
 const findCSSAssetUrls = require('./src/findCSSAssetUrls');
+const loadHappoConfig = require('./src/loadHappoConfig');
 const makeAbsolute = require('./src/makeAbsolute');
-const resolveEnvironment = require('./src/resolveEnvironment');
 
 let snapshots;
 let allCssBlocks;
 let snapshotAssetUrls;
 let baseUrl;
 let happoConfig;
-let isEnabled;
-let knownComponentVariants;
+let knownComponentVariants = {};
 
 async function downloadCSSContent(blocks, baseUrl) {
   const promises = blocks.map(async block => {
@@ -54,7 +49,7 @@ module.exports = {
     component,
     variant: rawVariant,
   }) {
-    if (!isEnabled) {
+    if (!happoConfig) {
       return null;
     }
     const variant = dedupeVariant(component, rawVariant);
@@ -70,33 +65,19 @@ module.exports = {
   },
 
   async happoInit(options) {
-    try {
-      happoConfig = await loadUserConfig('./.happo.js');
-      isEnabled = true;
-    } catch (e) {
-      if (/You need an.*apiKey/.test(e.message)) {
-        isEnabled = false;
-        console.warn(
-          "[HAPPO] Happo is disabled since we couldn't find an `apiKey` and/or `apiSecret`",
-        );
-      } else {
-        throw e;
-      }
-    }
+    happoConfig = await loadHappoConfig();
     snapshots = [];
     allCssBlocks = [];
     snapshotAssetUrls = new Set();
     baseUrl = options.baseUrl;
-    knownComponentVariants = {};
     return null;
   },
 
   async happoTeardown() {
-    if (!isEnabled) {
+    if (!happoConfig) {
       return null;
     }
     if (!snapshots.length) {
-      console.log(`[HAPPO] No snapshots were recorded. Ignoring.`);
       return null;
     }
     await downloadCSSContent(allCssBlocks, baseUrl);
@@ -127,46 +108,16 @@ module.exports = {
         allRequestIds.push(...requestIds);
       }),
     );
-    const { beforeSha, afterSha, link, message } = resolveEnvironment();
-    const reportResult = await makeRequest(
-      {
-        url: `${happoConfig.endpoint}/api/async-reports/${afterSha}`,
-        method: 'POST',
-        json: true,
-        body: {
-          requestIds: allRequestIds,
-          project: happoConfig.project,
-        },
-      },
-      { ...happoConfig, maxTries: 3 },
-    );
-
-    if (beforeSha) {
-      const jobResult = await makeRequest(
-        {
-          url: `${happoConfig.endpoint}/api/jobs/${beforeSha}/${afterSha}`,
-          method: 'POST',
-          json: true,
-          body: {
-            project: happoConfig.project,
-            link,
-            message,
-          },
-        },
-        { ...happoConfig, maxTries: 3 },
+    const fetchRes = await nodeFetch('http://localhost:5338/', {
+      method: 'POST',
+      body: allRequestIds.join('\n'),
+    });
+    if (!fetchRes.ok) {
+      console.error(
+        `[HAPPO] Failed to communicate with happo-cypress process — ${fetchRes.statusText}`,
       );
-      if (beforeSha !== afterSha) {
-        await compareReports(beforeSha, afterSha, happoConfig, {
-          link,
-          message,
-          isAsync: true,
-        });
-      }
-      console.log(`[HAPPO] ${jobResult.url}`);
-    } else {
-      console.log(`[HAPPO] ${reportResult.url}`);
+      return;
     }
-
     return null;
   },
 };


### PR DESCRIPTION
After a lot of debugging and exploration, I've landed in a fix for the
problem where a Cypress run creates multiple happo reports, one per test
file.

This was first reported last week and to begin with I couldn't repro it.
In short, this was the bug:

When you have multiple test files, Happo creates one report per file,
instead of one combined report.

When running with `cypress open`, the `after` hook was only called once
per full run. But if you ran `cypress run`, the behavior changed to
calling `after` once per test file. There's a bug for this in the
Cypress issue tracker: https://github.com/cypress-io/cypress/issues/5160

To mitigate this, I tried hard to find a place/hook or something where
Cypress would tell me one of these things:
The full suite is done, or
These are the specs in the full run

Either of those would be sufficient enough for our plugin to
conditionally create the Happo report once the `after` hook is called
for the last time. But I couldn't find any of this information available
from Cypress. So I did what Percy.io is doing -- added a wrapper command
that you need to use instead of `cypress run`:

happo-cypress -- cypress run

This call will set up a server locally, invoke the wrapped command,
accept `requestIds` to be POSTed to the server and then finally, once
the wrapped command is done, create the full Happo report.

It's a little unfortunate that we have to go down this route as there's
a lot of complexity involved:
- Users will have to make sure to wrap the Cypress command
- We have to be careful about choosing a good port (for now this is
hard-coded).