### PR TITLE
Resolve assets base

### DIFF
--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -25,9 +25,9 @@ function normalize(url, baseUrl) {
   }
 }
 
-module.exports = function createAssetPackage({ urls, baseUrl }) {
+module.exports = function createAssetPackage(urls) {
   // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve) => {
+  return new Promise(async resolve => {
     const archive = new Archiver('zip');
     archive.on('error', e => console.error(e));
 
@@ -46,11 +46,15 @@ module.exports = function createAssetPackage({ urls, baseUrl }) {
     archive.pipe(stream);
 
     const promises = urls
-      .filter(url => url.startsWith('/') || url.startsWith(baseUrl))
-      .map(async url => {
+      .filter(
+        ({ url, baseUrl }) => url.startsWith('/') || url.startsWith(baseUrl),
+      )
+      .map(async ({ url, baseUrl }) => {
         const fetchRes = await nodeFetch(makeAbsolute(url, baseUrl));
         if (!fetchRes.ok) {
-          console.log(`[HAPPO] Failed to fetch url ${url} — ${fetchRes.statusText}`);
+          console.log(
+            `[HAPPO] Failed to fetch url ${url} — ${fetchRes.statusText}`,
+          );
           return;
         }
         archive.append(fetchRes.body, {

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -50,7 +50,7 @@ module.exports = function createAssetPackage({ urls, baseUrl }) {
       .map(async url => {
         const fetchRes = await nodeFetch(makeAbsolute(url, baseUrl));
         if (!fetchRes.ok) {
-          console.log(`Failed to fetch url ${url} — ${fetchRes.statusText}`);
+          console.log(`[HAPPO] Failed to fetch url ${url} — ${fetchRes.statusText}`);
           return;
         }
         archive.append(fetchRes.body, {


### PR DESCRIPTION
This PR should fix #5. 

We can't assume assets are located on the same origin as what's defined as the `baseUrl` in cypress.json. Instead, we always have to look them up with the document's base url (`document.location.origin`). 