### PR TITLE
Add `targets` option to `happoScreenshot`

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -8,6 +8,7 @@ describe('The Home Page', () => {
     cy.get('.button').happoScreenshot({
       component: 'Button',
       variant: 'default',
+      targets: ['chromeSmall'],
     });
 
     cy.get('.images').happoScreenshot({

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ Cypress.Commands.add(
         assetUrls,
         component,
         variant,
+        targets: options.targets,
       });
     });
   },

--- a/task.js
+++ b/task.js
@@ -64,13 +64,14 @@ module.exports = {
     cssBlocks,
     component,
     variant: rawVariant,
+    targets,
   }) {
     if (!happoConfig) {
       return null;
     }
     const variant = dedupeVariant(component, rawVariant);
     snapshotAssetUrls.push(...assetUrls);
-    snapshots.push({ html, component, variant });
+    snapshots.push({ html, component, variant, targets });
     cssBlocks.forEach(block => {
       if (allCssBlocks.some(b => b.key === block.key)) {
         return;
@@ -110,13 +111,16 @@ module.exports = {
     const allRequestIds = [];
     await Promise.all(
       Object.keys(happoConfig.targets).map(async name => {
+        const snapshotsForTarget = snapshots.filter(
+          ({ targets }) => !targets || targets.includes(name),
+        );
         const requestIds = await happoConfig.targets[name].execute({
           targetName: name,
           asyncResults: true,
           endpoint: happoConfig.endpoint,
           globalCSS,
           assetsPackage,
-          snapPayloads: snapshots,
+          snapPayloads: snapshotsForTarget,
           apiKey: happoConfig.apiKey,
           apiSecret: happoConfig.apiSecret,
         });


### PR DESCRIPTION
This will allow people to limit the number of targets for which they
generate screenshots. This is similar to what we do for Happo Examples:
https://docs.happo.io/docs/examples#limiting-targets