### PR TITLE
Add Cypress run that execute in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,3 +22,15 @@ workflows:
           yarn: true
           start: yarn dev
           command: node bin/happo-cypress.js -- yarn cypress run
+  cypress-parallel:
+    jobs:
+      - cypress/install
+      - cypress/run:
+          requires:
+            - cypress/install
+          yarn: true
+          start: yarn dev
+          parallel: true
+          parallelism: 2
+          record: true
+          command: HAPPO_PROJECT=parallel node bin/happo-cypress.js -- yarn cypress run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ workflows:
           command: node bin/happo-cypress.js -- yarn cypress run
   cypress-parallel:
     jobs:
-      - cypress/install
+      - cypress/install:
+          yarn: true
       - cypress/run:
           requires:
             - cypress/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,4 @@ workflows:
           parallel: true
           parallelism: 2
           record: true
-          command: HAPPO_PROJECT=parallel node bin/happo-cypress.js -- yarn cypress run
+          command-prefix: HAPPO_PROJECT=parallel node bin/happo-cypress.js -- yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,15 @@ jobs:
           steps:
             - run: yarn install
             - run: yarn lint
+  finalize-happo:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: yarn install
+            - run: "HAPPO_NONCE=${CIRCLE_BUILD_NUM} node bin/happo-cypress.js finalize"
 workflows:
   build-and-test:
     jobs:
@@ -21,7 +30,7 @@ workflows:
       - cypress/run:
           yarn: true
           start: yarn dev
-          command: node bin/happo-cypress.js -- yarn cypress run
+          command-prefix: node bin/happo-cypress.js -- yarn cypress run
   cypress-parallel:
     jobs:
       - cypress/install:
@@ -34,4 +43,7 @@ workflows:
           parallel: true
           parallelism: 2
           record: true
-          command-prefix: HAPPO_PROJECT=parallel node bin/happo-cypress.js -- yarn
+          command-prefix: "HAPPO_PROJECT=parallel HAPPO_NONCE=${CIRCLE_BUILD_NUM} node bin/happo-cypress.js -- yarn"
+      - finalize-happo:
+          requires:
+            - cypress/run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - node/with-cache:
           steps:
             - run: yarn install
-            - run: "HAPPO_NONCE=${CIRCLE_WORKFLOW_ID} node bin/happo-cypress.js finalize"
+            - run: "HAPPO_PROJECT=parallel HAPPO_NONCE=${CIRCLE_WORKFLOW_ID} node bin/happo-cypress.js finalize"
 workflows:
   build-and-test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - node/with-cache:
           steps:
             - run: yarn install
-            - run: "HAPPO_NONCE=${CIRCLE_BUILD_NUM} node bin/happo-cypress.js finalize"
+            - run: "HAPPO_NONCE=${CIRCLE_WORKFLOW_ID} node bin/happo-cypress.js finalize"
 workflows:
   build-and-test:
     jobs:
@@ -43,7 +43,7 @@ workflows:
           parallel: true
           parallelism: 2
           record: true
-          command-prefix: "HAPPO_PROJECT=parallel HAPPO_NONCE=${CIRCLE_BUILD_NUM} node bin/happo-cypress.js -- yarn"
+          command-prefix: "HAPPO_PROJECT=parallel HAPPO_NONCE=${CIRCLE_WORKFLOW_ID} node bin/happo-cypress.js -- yarn"
       - finalize-happo:
           requires:
             - cypress/run

--- a/.happo.js
+++ b/.happo.js
@@ -1,6 +1,7 @@
 const { RemoteBrowserTarget } = require('happo.io');
 
 module.exports = {
+  project: process.env.HAPPO_PROJECT,
   targets: {
     chrome: new RemoteBrowserTarget('chrome', {
       viewport: '1024x768',

--- a/bin/happo-cypress.js
+++ b/bin/happo-cypress.js
@@ -53,7 +53,7 @@ async function finalizeAll() {
   if (!nonce) {
     throw new Error('[HAPPO] Missing HAPPO_NONCE environment variable');
   }
-  const finalizeResult = await makeRequest(
+  await makeRequest(
     {
       url: `${happoConfig.endpoint}/api/async-reports/${afterSha}/finalize`,
       method: 'POST',
@@ -67,7 +67,7 @@ async function finalizeAll() {
   );
 
   if (beforeSha && beforeSha !== afterSha) {
-    const compareResult = await compareReports(beforeSha, afterSha, happoConfig, {
+    await compareReports(beforeSha, afterSha, happoConfig, {
       link,
       message,
       isAsync: true,
@@ -138,7 +138,7 @@ function startServer(port) {
 async function init(argv) {
   const dashdashIndex = argv.indexOf('--');
   if (dashdashIndex === -1) {
-    const isFinalizeCommand = argv[argv.length -1] === 'finalize';
+    const isFinalizeCommand = argv[argv.length - 1] === 'finalize';
     if (isFinalizeCommand) {
       await finalizeAll();
       return;
@@ -175,7 +175,7 @@ async function init(argv) {
   });
 }
 
-init(process.argv).catch((e) => {
+init(process.argv).catch(e => {
   console.error(e);
   process.exit(1);
-});;
+});

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:7654"
+  "baseUrl": "http://localhost:7654",
+  "projectId": "w56536"
 }

--- a/cypress/integration/second_page_spec.js
+++ b/cypress/integration/second_page_spec.js
@@ -1,6 +1,6 @@
 describe('A different page', () => {
   it('has happo tests', () => {
     cy.visit('/');
-    cy.get('.card').happoScreenshot({ component: 'Card' });
+    cy.get('.card').happoScreenshot({ component: 'Card', variant: 'from page' });
   });
 });

--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -123,5 +123,6 @@ module.exports = function resolveEnvironment(env = process.env) {
     message: /^dev-/.test(afterSha) ? undefined : resolveMessage(env),
     beforeSha: resolveBeforeSha(env, afterSha),
     afterSha,
+    nonce: env.HAPPO_NONCE,
   };
 };


### PR DESCRIPTION
I'm adding support for a `happo-cypress finalize` command, which will be
used for test suites that execute in parallel. Before I work on the
finalize command, I want to make sure I can run parallel Cypress runs.

The second cypress run will show up as a "Happo (parallel)" build
status (eventually).