### PR TITLE
Simplify and speed up cypress runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
             - cypress/install
           yarn: true
           start: yarn dev
-          command-prefix: node bin/happo-cypress.js -- yarn cypress run
+          command-prefix: node bin/happo-cypress.js -- yarn
       - cypress/run:
           name: cypress-parallel
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,14 @@ workflows:
       - cypress/install:
           yarn: true
       - cypress/run:
+          name: cypress-serial
           requires:
             - cypress/install
           yarn: true
           start: yarn dev
           command-prefix: node bin/happo-cypress.js -- yarn cypress run
       - cypress/run:
+          name: cypress-parallel
           requires:
             - cypress/install
           yarn: true
@@ -46,4 +48,4 @@ workflows:
           command-prefix: "HAPPO_PROJECT=parallel HAPPO_NONCE=${CIRCLE_WORKFLOW_ID} node bin/happo-cypress.js -- yarn"
       - finalize-happo:
           requires:
-            - cypress/run
+            - cypress-parallel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ workflows:
       - build-and-test
   cypress:
     jobs:
+      - cypress/install:
+          yarn: true
       - cypress/run:
+          requires:
+            - cypress/install
           yarn: true
           start: yarn dev
           command-prefix: node bin/happo-cypress.js -- yarn cypress run
-  cypress-parallel:
-    jobs:
-      - cypress/install:
-          yarn: true
       - cypress/run:
           requires:
             - cypress/install


### PR DESCRIPTION
Now that we have two separate runs (one serial and the other parallel),
we can optimize builds a little by combining them in the same job and
reusing the install phase.