### PR TITLE
Inline canvases as PNG images

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -1,10 +1,12 @@
 describe('The Home Page', () => {
   it('successfully loads', () => {
     cy.visit('/');
+    cy.wait(100);
     cy.get('body').happoScreenshot({ component: 'Full-page' });
     cy.get('.card').happoScreenshot({ component: 'Card' });
 
     cy.visit('/');
+    cy.wait(100);
     cy.get('.button').happoScreenshot({
       component: 'Button',
       variant: 'default',
@@ -16,9 +18,10 @@ describe('The Home Page', () => {
       variant: 'multiple',
     });
 
+    cy.get('.button').happoScreenshot();
+    cy.get('.button').happoScreenshot();
+    cy.get('.button').happoScreenshot();
 
-    cy.get('.button').happoScreenshot();
-    cy.get('.button').happoScreenshot();
-    cy.get('.button').happoScreenshot();
+    cy.get('canvas').happoScreenshot({ component: 'Canvas' });
   });
 });

--- a/index.js
+++ b/index.js
@@ -79,8 +79,12 @@ function inlineCanvases(doc, subject) {
     const image = doc.createElement('img');
     const canvasImageBase64 = canvas.toDataURL('image/png');
     image.src = canvasImageBase64;
+    const style = window.getComputedStyle(canvas, '');
+    image.style.cssText = style.cssText;
     canvas.replaceWith(image);
     if (canvas === subject) {
+      // We're inlining the subject (the `cy.get('canvas')` element). Make sure
+      // we return the modified subject.
       newSubject = image;
     }
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ function CanvasImage() {
     ctx.fillText('Hello World', 20, 50);
   });
 
-  return <canvas ref={ref} width="200" height="100" />;
+  return <canvas style={{ padding: 20 }} ref={ref} width="200" height="100" />;
 }
 
 export default function IndexPage() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,19 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
+
+function CanvasImage() {
+  const ref = useRef();
+  useEffect(() => {
+    const ctx = ref.current.getContext('2d');
+    ctx.moveTo(0, 0);
+    ctx.lineTo(200, 100);
+    ctx.stroke();
+    ctx.font = '30px Arial';
+    ctx.rotate(0.25);
+    ctx.fillText('Hello World', 20, 50);
+  });
+
+  return <canvas ref={ref} width="200" height="100" />;
+}
 
 export default function IndexPage() {
   useEffect(() => {
@@ -10,6 +25,7 @@ export default function IndexPage() {
 
   return (
     <div>
+      <CanvasImage />
       <div className="card">
         <h1>I'm a card</h1>
         <img src="/hotel.jpg" />

--- a/public/global.css
+++ b/public/global.css
@@ -15,3 +15,7 @@ body {
 button {
   font-family: 'CustomFont';
 }
+
+canvas {
+  border: 2px solid red;
+}


### PR DESCRIPTION
This commit will make sure that happo-cypress users can screenshoot
canvases. These are dynamically painted to, and there's no information
in the DOM about what they contain. So we take the canvas and convert it
to a PNG file.