### PR TITLE
Don't attempt to inline tainted canvases

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -22,6 +22,13 @@ describe('The Home Page', () => {
     cy.get('.button').happoScreenshot();
     cy.get('.button').happoScreenshot();
 
-    cy.get('canvas').happoScreenshot({ component: 'Canvas' });
+    cy.get('[data-test="untainted-canvas"]').happoScreenshot({
+      component: 'Canvas',
+      variant: 'untainted',
+    });
+    cy.get('[data-test="tainted-canvas"]').happoScreenshot({
+      component: 'Canvas',
+      variant: 'tainted',
+    });
   });
 });

--- a/index.js
+++ b/index.js
@@ -78,17 +78,26 @@ function inlineCanvases(doc, subject) {
   const replacements = [];
   for (const canvas of canvases) {
     const image = doc.createElement('img');
-    const canvasImageBase64 = canvas.toDataURL('image/png');
-    image.src = canvasImageBase64;
-    const style = window.getComputedStyle(canvas, '');
-    image.style.cssText = style.cssText;
-    canvas.replaceWith(image);
-    if (canvas === subject) {
-      // We're inlining the subject (the `cy.get('canvas')` element). Make sure
-      // we return the modified subject.
-      newSubject = image;
+    try {
+      const canvasImageBase64 = canvas.toDataURL('image/png');
+      image.src = canvasImageBase64;
+      const style = window.getComputedStyle(canvas, '');
+      image.style.cssText = style.cssText;
+      canvas.replaceWith(image);
+      if (canvas === subject) {
+        // We're inlining the subject (the `cy.get('canvas')` element). Make sure
+        // we return the modified subject.
+        newSubject = image;
+      }
+      replacements.push({ from: canvas, to: image });
+    } catch (e) {
+      if (e.name === 'SecurityError') {
+        console.warn('[HAPPO] Failed to convert tainted canvas to PNG image');
+        console.warn(e);
+      } else {
+        throw e;
+      }
     }
-    replacements.push({ from: canvas, to: image });
   }
 
   function cleanup() {

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,37 @@ function CanvasImage() {
     ctx.fillText('Hello World', 20, 50);
   });
 
-  return <canvas style={{ padding: 20 }} ref={ref} width="200" height="100" />;
+  return (
+    <canvas
+      data-test="untainted-canvas"
+      style={{ padding: 20 }}
+      ref={ref}
+      width="200"
+      height="100"
+    />
+  );
+}
+
+function TaintedCanvasImage() {
+  const ref = useRef();
+  useEffect(() => {
+    const ctx = ref.current.getContext('2d');
+    const img = new Image();
+    img.addEventListener('load', () => {
+      ctx.drawImage(img, 0, 0);
+    });
+    img.src = 'https://placekitten.com/100/100';
+  });
+
+  return (
+    <canvas
+      data-test="tainted-canvas"
+      style={{ padding: 20 }}
+      ref={ref}
+      width="200"
+      height="100"
+    />
+  );
 }
 
 export default function IndexPage() {
@@ -26,6 +56,7 @@ export default function IndexPage() {
   return (
     <div>
       <CanvasImage />
+      <TaintedCanvasImage />
       <div className="card">
         <h1>I'm a card</h1>
         <img src="/hotel.jpg" />


### PR DESCRIPTION
If we come across a canvas with an external image, and the CORS settings
of the external image isn't allowing it to be pixel-inspected, the call
to ctx.toDataURL() will fail with a SecurityError. We can catch this
error, log a warning and simply move along.