### PR TITLE
Add spec file without screenshots to cypress run

### DIFF
--- a/cypress/integration/no_happo_spec.js
+++ b/cypress/integration/no_happo_spec.js
@@ -1,0 +1,5 @@
+describe('A test with no happoScreenshot calls', () => {
+  it('successfully loads', () => {
+    cy.visit('/');
+  });
+});


### PR DESCRIPTION
I'm trying to figure out if this could be causing failures down the
line. We're seeing 500 status responses for async-reports, coming from
the happo-cypress module:

Failed POST
https://happo.io/api/async-reports/ddefdac62def4deddd39a04d7c379d932d85119c.

SequelizeDatabaseError: Column 'snapRequestId' cannot be null
    at Query.formatError (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:244:16)
    at Query.handler [as onResult] (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:51
:23)
    at Query.execute (/usr/src/app/node_modules/mysql2/lib/commands/command.js:30:14)
    at Connection.handlePacket (/usr/src/app/node_modules/mysql2/lib/connection.js:408:32)
    at PacketParser.onPacket (/usr/src/app/node_modules/mysql2/lib/connection.js:70:12)
    at PacketParser.executeStart (/usr/src/app/node_modules/mysql2/lib/packet_parser.js:75:16)
    at Socket.<anonymous> (/usr/src/app/node_modules/mysql2/lib/connection.js:77:25)
    at Socket.emit (events.js:315:20)
    at Socket.EventEmitter.emit (domain.js:505:15)
    at addChunk (_stream_readable.js:295:12)
    at readableAddChunk (_stream_readable.js:271:9)
    at Socket.Readable.push (_stream_readable.js:212:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
(node:1) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the