### PR TITLE
Upload assets separately from the snapshots payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.4.1",
+  "version": "1.5.0-rc.1",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -1,6 +1,8 @@
-const { Writable } = require('stream');
-const nodeFetch = require('node-fetch');
+const crypto = require('crypto');
 const Archiver = require('archiver');
+const nodeFetch = require('node-fetch');
+
+const { Writable } = require('stream');
 
 const makeAbsolute = require('./makeAbsolute');
 
@@ -42,7 +44,8 @@ module.exports = function createAssetPackage(urls) {
     stream.on('error', e => console.error(e));
     stream.on('finish', () => {
       const buffer = Buffer.from(data);
-      resolve(buffer);
+      const hash = crypto.createHash('md5').update(buffer).digest('hex');
+      resolve({ buffer, hash });
     });
     archive.pipe(stream);
 


### PR DESCRIPTION
This commit will split out assets package handling from the full payload
into a separate call. This will allow us to reuse assets between
snap-requests and will make the individual snap-request payloads smaller
since assets are no longer baked in with them.