### PR TITLE
Be less aggressive about copying over canvas styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,8 +94,14 @@ function inlineCanvases(doc, subject) {
         .digest('hex')}.png`;
       image.src = url;
       image._base64Url = canvasImageBase64;
-      const style = window.getComputedStyle(canvas, '');
-      image.style.cssText = style.cssText;
+      const style = canvas.getAttribute('style');
+      const className = canvas.getAttribute('class');
+      const width = canvas.getAttribute('width');
+      const height = canvas.getAttribute('height');
+      image.setAttribute('style', style);
+      image.setAttribute('class', className);
+      image.setAttribute('width', width);
+      image.setAttribute('height', height);
       canvas.replaceWith(image);
       if (canvas === subject) {
         // We're inlining the subject (the `cy.get('canvas')` element). Make sure

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,7 @@ function CanvasImage() {
 
   return (
     <canvas
+      className="canvas"
       data-test="untainted-canvas"
       style={{ padding: 20 }}
       ref={ref}
@@ -36,6 +37,7 @@ function TaintedCanvasImage() {
 
   return (
     <canvas
+      className="canvas"
       data-test="tainted-canvas"
       style={{ padding: 20 }}
       ref={ref}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-function CanvasImage() {
+function CanvasImage({ responsive }) {
   const ref = useRef();
   useEffect(() => {
     const ctx = ref.current.getContext('2d');
@@ -16,10 +16,10 @@ function CanvasImage() {
     <canvas
       className="canvas"
       data-test="untainted-canvas"
-      style={{ padding: 20 }}
+      style={{ padding: 20, width: responsive ? 'calc(100% - 40px)' : undefined }}
       ref={ref}
-      width="200"
-      height="100"
+      width={responsive ? undefined : '200'}
+      height={responsive ? undefined : '100'}
     />
   );
 }
@@ -62,6 +62,7 @@ export default function IndexPage() {
       <div className="card">
         <h1>I'm a card</h1>
         <img src="/hotel.jpg" />
+        <CanvasImage responsive />
       </div>
       <button className="button">Click me</button>
       <div className="images">

--- a/public/global.css
+++ b/public/global.css
@@ -16,6 +16,6 @@ button {
   font-family: 'CustomFont';
 }
 
-canvas {
+.canvas {
   border: 2px solid red;
 }


### PR DESCRIPTION
When inlining canvases, we were calling getComputedStyle to get all the
styles from the canvas over to the image. That worked well if the screen
size is static, but on responsive setups that becomes a problem. Since
getComputedStyle contains width and height, the inlined image will be
statically sized after the canvas at the size it was rendered in the
cypress test, which might be a larger or smaller size than what it would
render as in other screen sizes.