### PR TITLE
Allow setting a HTTP_PROXY environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "archiver": "^3.1.1",
+    "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.0",
     "parse-srcset": "^1.0.2"
   }

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -1,10 +1,13 @@
 const crypto = require('crypto');
 const Archiver = require('archiver');
 const nodeFetch = require('node-fetch');
+const HttpsProxyAgent = require('https-proxy-agent');
 
 const { Writable } = require('stream');
 
 const makeAbsolute = require('./makeAbsolute');
+
+const { HTTP_PROXY } = process.env;
 
 const FILE_CREATION_DATE = new Date(
   'Fri March 20 2020 13:44:55 GMT+0100 (CET)',
@@ -68,7 +71,14 @@ module.exports = function createAssetPackage(urls) {
             date: FILE_CREATION_DATE,
           });
         } else {
-          const fetchRes = await nodeFetch(makeAbsolute(url, baseUrl));
+          const fetchOptions = {};
+          if (HTTP_PROXY) {
+            fetchOptions.agent = new HttpsProxyAgent(HTTP_PROXY);
+          }
+          const fetchRes = await nodeFetch(
+            makeAbsolute(url, baseUrl),
+            fetchOptions,
+          );
           if (!fetchRes.ok) {
             console.log(
               `[HAPPO] Failed to fetch url ${url} — ${fetchRes.statusText}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,13 @@ adjust-sourcemap-loader@2.0.0:
     object-path "0.11.4"
     regex-parser "2.2.10"
 
+agent-base@6:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
+  integrity sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
+  dependencies:
+    debug "4"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -2672,7 +2679,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4.1.1, debug@^4.0.1, debug@^4.1.0:
+debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -3884,6 +3891,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
Some users need to proxy all outgoing traffic when running Cypress. It
already has support for a forward proxy via HTTP_PROXY:
https://docs.cypress.io/guides/references/proxy-configuration.html

We can tag along the same setup here. For requests made by the happo.io
library we're using the `request` module, which already supports
HTTP_PROXY. We just need to patch node-fetch, as described in this
issue:
https://github.com/node-fetch/node-fetch/issues/195