### PR TITLE
Use shell when spawning on Windows

### DIFF
--- a/bin/happo-cypress.js
+++ b/bin/happo-cypress.js
@@ -171,6 +171,7 @@ async function init(argv) {
   const child = spawn(commandParts[0], commandParts.slice(1), {
     stdio: 'inherit',
     env: { ...process.env, HAPPO_CYPRESS_PORT: serverPort },
+    shell: process.platform == 'win32',
   });
 
   child.on('error', e => {


### PR DESCRIPTION
I was debugging why environment variables weren't working in a windows
environment and found that the PATH variable was never passed along with
the command.

Found a solution here:
https://stackoverflow.com/questions/37459717/error-spawn-enoent-on-windows

Making this conditional on OS seems like the safest option here.