### PR TITLE
Proxy link[href]s as well

### DIFF
--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -1,13 +1,12 @@
 const crypto = require('crypto');
 const Archiver = require('archiver');
-const nodeFetch = require('node-fetch');
-const HttpsProxyAgent = require('https-proxy-agent');
 
 const { Writable } = require('stream');
 
+const proxiedFetch = require('./fetch');
 const makeAbsolute = require('./makeAbsolute');
 
-const { HTTP_PROXY, HAPPO_DEBUG, HAPPO_DOWNLOAD_ALL } = process.env;
+const { HAPPO_DOWNLOAD_ALL } = process.env;
 
 const FILE_CREATION_DATE = new Date(
   'Fri March 20 2020 13:44:55 GMT+0100 (CET)',
@@ -73,18 +72,8 @@ module.exports = function createAssetPackage(urls) {
           date: FILE_CREATION_DATE,
         });
       } else {
-        const fetchOptions = {};
-        if (HTTP_PROXY) {
-          fetchOptions.agent = new HttpsProxyAgent(HTTP_PROXY);
-        }
-        if (HAPPO_DEBUG) {
-          console.log(
-            `[HAPPO] using the following node-fetch options`,
-            fetchOptions,
-          );
-        }
         const fetchUrl = makeAbsolute(url, baseUrl);
-        const fetchRes = await nodeFetch(fetchUrl, fetchOptions);
+        const fetchRes = await proxiedFetch(fetchUrl);
         if (!fetchRes.ok) {
           console.log(
             `[HAPPO] Failed to fetch url ${fetchUrl} — ${fetchRes.statusText}`,

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,0 +1,17 @@
+const nodeFetch = require('node-fetch');
+const HttpsProxyAgent = require('https-proxy-agent');
+
+const { HTTP_PROXY, HAPPO_DEBUG } = process.env;
+
+const fetchOptions = {};
+if (HTTP_PROXY) {
+  fetchOptions.agent = new HttpsProxyAgent(HTTP_PROXY);
+}
+if (HAPPO_DEBUG) {
+  console.log(`[HAPPO] using the following node-fetch options`, fetchOptions);
+}
+
+module.exports = async function fetch(url) {
+  const fetchRes = await nodeFetch(url, fetchOptions);
+  return fetchRes;
+};

--- a/task.js
+++ b/task.js
@@ -3,6 +3,7 @@ const nodeFetch = require('node-fetch');
 const makeRequest = require('happo.io/build/makeRequest').default;
 
 const createAssetPackage = require('./src/createAssetPackage');
+const proxiedFetch = require('./src/fetch');
 const findCSSAssetUrls = require('./src/findCSSAssetUrls');
 const loadHappoConfig = require('./src/loadHappoConfig');
 const makeAbsolute = require('./src/makeAbsolute');
@@ -43,7 +44,7 @@ async function downloadCSSContent(blocks) {
   const promises = blocks.map(async block => {
     if (block.href) {
       const absUrl = makeAbsolute(block.href, block.baseUrl);
-      const res = await nodeFetch(absUrl);
+      const res = await proxiedFetch(absUrl);
       if (!res.ok) {
         console.warn(
           `[HAPPO] Failed to fetch CSS file from ${block.href}. This might mean styles are missing in your Happo screenshots`,


### PR DESCRIPTION
I recently added support for setting a HTTP_PROXY, but I managed to miss
that we were fetching stylesheets via a fetch call as well. This commit
unifies all fetch calls into a module, which makes it so that we can set
the proxy settings in a single place.