### PR TITLE
Prevent fetching assets for `url(#ref)`

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -76,6 +76,7 @@ export default function IndexPage() {
       <CanvasImage />
       <TaintedCanvasImage />
       <EmptyCanvasImage />
+      <div style={{ background: 'url(#shadow)' }} />
       <div className="card">
         <h1>I'm a card</h1>
         <i

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -27,6 +27,7 @@ function normalize(url, baseUrl) {
   if (url.startsWith('/')) {
     return url.slice(1);
   }
+  return url;
 }
 
 module.exports = function createAssetPackage(urls) {
@@ -68,6 +69,9 @@ module.exports = function createAssetPackage(urls) {
       const name = isExternalUrl
         ? `_external/${crypto.createHash('md5').update(url).digest('hex')}`
         : normalize(stripQueryParams(url), baseUrl);
+      if (name.startsWith('#')) {
+        return;
+      }
       if (seenUrls.has(name)) {
         // already processed
         return;


### PR DESCRIPTION
We've seen this error in the wild:

[HAPPO] Fetching asset from https://<redacted>/#shadow — storing as undefined
ArchiverError: entry name must be a non-empty string value
    at Archiver.append (/root/project/js/webapp/node_modules/archiver/lib/core.js:559:24)
    at /root/project/js/webapp/node_modules/happo-cypress/src/createAssetPackage.js:96:17
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async Promise.all (index 6)
    at async /root/project/js/webapp/node_modules/happo-cypress/src/createAssetPackage.js:104:5 {
  message: 'entry name must be a non-empty string value',
  code: 'ENTRYNAMEREQUIRED',

This error is causing happoTeardown to silently fail (times out after 1
min).

We can fix this by ignoring these asset urls.