### PR TITLE
Resolve relative paths in css files

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -25,6 +25,7 @@ class MyDocument extends Document {
             rel="stylesheet"
           />
           <link href="/global.css" rel="stylesheet" />
+          <link href="/fonts/fonts.css" rel="stylesheet" />
         </Head>
         <body>
           <Main />

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: 'CustomFont';
+  src: url('../Lato-Bold.woff2') format('woff2');
+}
+
+body, button {
+  font-family: 'CustomFont';
+}

--- a/public/global.css
+++ b/public/global.css
@@ -1,19 +1,9 @@
-@font-face {
-  font-family: 'CustomFont';
-  src: url('/Lato-Bold.woff2') format('woff2');
-}
-
 body {
-  font-family: 'CustomFont';
   padding: 20px;
   background-color: #f0f0f0;
 
   /* Override next.js style active during page load */
   display: block !important;
-}
-
-button {
-  font-family: 'CustomFont';
 }
 
 .canvas {

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -27,6 +27,9 @@ function normalize(url, baseUrl) {
   if (url.startsWith('/')) {
     return url.slice(1);
   }
+  if (url.startsWith('../')) {
+    return url.slice(3);
+  }
   return url;
 }
 

--- a/src/makeAbsolute.js
+++ b/src/makeAbsolute.js
@@ -1,9 +1,14 @@
+const { URL } = require('url');
+
 module.exports = function makeAbsolute(url, baseUrl) {
   if (url.startsWith('//')) {
     return `${baseUrl.split(':')[0]}:${url}`;
   }
   if (url.startsWith('/')) {
     return `${baseUrl}${url}`;
+  }
+  if (url.startsWith('.')) {
+    return new URL(`${baseUrl}${url}`).href;
   }
   if (/^https?:/.test(url)) {
     return url;

--- a/task.js
+++ b/task.js
@@ -64,6 +64,7 @@ async function downloadCSSContent(blocks) {
         text = makeExternalUrlsAbsolute(text, absUrl);
       }
       block.content = text;
+      block.assetsBaseUrl = absUrl.replace(/\/[^/]*$/, '/');
       delete block.href;
     }
   });
@@ -124,7 +125,7 @@ module.exports = {
     const allUrls = [...snapshotAssetUrls];
     allCssBlocks.forEach(block => {
       findCSSAssetUrls(block.content).forEach(url =>
-        allUrls.push({ url, baseUrl: block.baseUrl }),
+        allUrls.push({ url, baseUrl: block.assetsBaseUrl || block.baseUrl }),
       );
     });
 

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -22,6 +22,10 @@ function runTest() {
     makeAbsolute('bar/foo.png', baseUrl),
     'https://base.url/bar/foo.png',
   );
+  assert.equal(
+    makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/'),
+    'http://goo.bar/bar/foo.png',
+  );
 }
 
 runTest();


### PR DESCRIPTION
If a css file is referencing an asset using a relative path, e.g.
"url(../fonts/foo.woff)", we weren't including the asset correctly in
the assets package. By improving how we resolve these assets we can make
sure that images, fonts, etc are included in the screenshots.