### PR TITLE
Don't collect css that's already been processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ function extractCSSBlocks({ doc }) {
   );
   const baseUrl = doc.location.origin;
   styleElements.forEach(element => {
+    if (element.__happoAlreadyProcessed) {
+      return;
+    }
     if (element.tagName === 'LINK') {
       // <link href>
       const href = element.getAttribute('href');
@@ -39,6 +42,7 @@ function extractCSSBlocks({ doc }) {
       const key = md5(content);
       blocks.push({ content, key, baseUrl });
     }
+    element.__happoAlreadyProcessed = true;
   });
   return blocks;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.7.4",
+  "version": "1.8.0-rc.1",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",


### PR DESCRIPTION
I'm trying to debug an issue where the html+css payload is very large in
some cases. After debugging, I found that the css collected for certain
test suites can contain multiple copies of the same styles. By tagging
css that's already been collected, we should be able to avoid the
duplication.