### PR TITLE
Ignore assets without urls

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -111,6 +111,11 @@ export default function IndexPage() {
             paddingTop: '33%',
           }}
         />
+        <div
+          style={{
+            backgroundImage: 'url()',
+          }}
+        />
         <picture>
           <source
             srcSet="/storyhotel-breakfast.jpg"

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -38,10 +38,10 @@ module.exports = function createAssetPackage(urls) {
     console.log(`[HAPPO] Creating asset package from urls`, urls);
   }
   // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async resolve => {
+  return new Promise(async (resolve, reject) => {
     const seenUrls = new Set();
     const archive = new Archiver('zip');
-    archive.on('error', e => console.error(e));
+    archive.on('error', e => reject(e));
 
     // Create an in-memory stream
     const stream = new Writable();
@@ -72,7 +72,7 @@ module.exports = function createAssetPackage(urls) {
       const name = isExternalUrl
         ? `_external/${crypto.createHash('md5').update(url).digest('hex')}`
         : normalize(stripQueryParams(url), baseUrl);
-      if (name.startsWith('#')) {
+      if (name.startsWith('#') || name === '') {
         return;
       }
       if (seenUrls.has(name)) {


### PR DESCRIPTION
I'm debugging a case where an asset is using an empty string as the src
url. The asset package fails somewhat silently with an error log and the
happoTeardown call times out.

We can ignore these assets as they won't work anyway. While I was at it,
I made the createAssetPackage function reject when an archiver error
happens. This will help users as the error will be propagated to the
Cypress process.