### PR TITLE
Reset knownComponentVariants when report is created

### DIFF
--- a/task.js
+++ b/task.js
@@ -214,6 +214,10 @@ module.exports = {
         { ...happoConfig, maxTries: 3 },
       );
       console.log(`[HAPPO] ${reportResult.url}`);
+
+      // Reset the component variants so that we can run the test again while
+      // cypress is still open.
+      knownComponentVariants = {};
       return null;
     }
     return null;


### PR DESCRIPTION
This fixes a bug where if you use `cypress open` and run the same test
twice in a row you'll end up with component variants being incorrect:

default-2 instead of default
large-2 instead of large
etc

In 711eb197, I removed the reset of the knownComponentVariants variable
since it messed up reports when using the happo-cypress wrapper. That
commit introduced the issue fixed here. We have to be careful about
resetting and only do it in the non-wrapper case, otherwise we might end
up with invalid reports.