### PR TITLE
Work around performance issues (timeouts) with happoRegisterSnapshot

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,14 +172,21 @@ Cypress.Commands.add(
       const html = subject.outerHTML;
       const assetUrls = getSubjectAssetUrls(subject, doc);
       const cssBlocks = extractCSSBlocks({ doc });
-      cy.task('happoRegisterSnapshot', {
-        html,
-        cssBlocks,
-        assetUrls,
-        component,
-        variant,
-        targets: options.targets,
-      });
+
+      // Even though cy.task can handle an object argument here, we serialize
+      // the object ourselves to avoid running into performance issues with
+      // large payloads. See https://github.com/cypress-io/code-coverage/issues/76
+      cy.task(
+        'happoRegisterSnapshot',
+        JSON.stringify({
+          html,
+          cssBlocks,
+          assetUrls,
+          component,
+          variant,
+          targets: options.targets,
+        }),
+      );
       if (transformCleanup) {
         transformCleanup();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.9.3",
+  "version": "1.9.4-rc.1",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",

--- a/task.js
+++ b/task.js
@@ -73,14 +73,19 @@ function dedupeVariant(component, variant) {
 }
 
 module.exports = {
-  happoRegisterSnapshot({
-    html,
-    assetUrls,
-    cssBlocks,
-    component,
-    variant: rawVariant,
-    targets,
-  }) {
+  // Even though task automatically serialize and deserialize arguments, we
+  // serialize the object ourselves to avoid running into performance issues
+  // with large payloads. See
+  // https://github.com/cypress-io/code-coverage/issues/76
+  happoRegisterSnapshot(jsonPayload) {
+    const {
+      html,
+      assetUrls,
+      cssBlocks,
+      component,
+      variant: rawVariant,
+      targets,
+    } = JSON.parse(jsonPayload);
     if (!happoConfig) {
       return null;
     }


### PR DESCRIPTION
We are currently seeing the `happoRegisterSnapshot` call time out in
certain test suites. It seems related to the size of the payloads sent
over the Cypress websocket -- we've only seen this with pages containing
large canvases (that get inlined as base64 images).

I was led to this solution after finding this Cypress issue:
https://github.com/cypress-io/code-coverage/issues/76

In that thread, it's suggested that you bypass the built-in
serialization and deserialization in Cypress by using JSON.stringify
yourself.