### PR TITLE
Split up html and css registering

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,6 +180,9 @@ Cypress.Commands.add(
         variant,
         targets: options.targets,
       });
+      cy.task('happoRegisterCSSBlocks', {
+        cssBlocks,
+      });
       if (transformCleanup) {
         transformCleanup();
       }

--- a/index.js
+++ b/index.js
@@ -174,7 +174,6 @@ Cypress.Commands.add(
       const cssBlocks = extractCSSBlocks({ doc });
       cy.task('happoRegisterSnapshot', {
         html,
-        cssBlocks,
         assetUrls,
         component,
         variant,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.9.4-rc.2",
+  "version": "1.9.4-rc.3",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.9.3",
+  "version": "1.9.4-rc.2",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",

--- a/task.js
+++ b/task.js
@@ -76,7 +76,6 @@ module.exports = {
   happoRegisterSnapshot({
     html,
     assetUrls,
-    cssBlocks,
     component,
     variant: rawVariant,
     targets,
@@ -87,6 +86,13 @@ module.exports = {
     const variant = dedupeVariant(component, rawVariant);
     snapshotAssetUrls.push(...assetUrls);
     snapshots.push({ html, component, variant, targets });
+    return null;
+  },
+
+  happoRegisterCSSBlocks({ cssBlocks }) {
+    if (!happoConfig) {
+      return null;
+    }
     cssBlocks.forEach(block => {
       if (allCssBlocks.some(b => b.key === block.key)) {
         return;


### PR DESCRIPTION
In an attempt to fix a timeout issue with happoRegisterSnapshot, I'm
breaking up css and html registering into two tasks. The idea here is
that sending them together in one payload leads to performance issues
and/or silent failures/timeouts.