### PR TITLE
Send inlined canvases separately from snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 cypress/videos
 cypress/screenshots
 .DS_Store
+.happo-tmp

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function getSubjectAssetUrls(subject, doc) {
     const style = element.getAttribute('style');
     const base64Url = element._base64Url;
     if (base64Url) {
-      allUrls.push({ url: src, baseUrl, base64Url });
+      cy.task('happoRegisterBase64Image', { base64Url, src });
     }
     if (src) {
       allUrls.push({ url: src, baseUrl });
@@ -91,7 +91,7 @@ function inlineCanvases(doc, subject) {
       }
       const image = doc.createElement('img');
 
-      const url = `/_inlined/${md5(canvasImageBase64).toString()}.png`;
+      const url = `/.happo-tmp/_inlined/${md5(canvasImageBase64).toString()}.png`;
       image.src = url;
       image._base64Url = canvasImageBase64;
       const style = canvas.getAttribute('style');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "archiver": "^3.1.1",
     "crypto-js": "^4.0.0",
     "https-proxy-agent": "^5.0.0",
+    "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.0",
     "parse-srcset": "^1.0.2",
     "string.prototype.replaceall": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happo-cypress",
-  "version": "1.9.3",
+  "version": "1.9.4-rc.4",
   "description": "A Happo integration with Cypress.io",
   "main": "index.js",
   "repository": "git@github.com:happo/happo-cypress.git",

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto');
-const Archiver = require('archiver');
 
+const Archiver = require('archiver');
 const { Writable } = require('stream');
 
 const proxiedFetch = require('./fetch');
@@ -64,7 +64,7 @@ module.exports = function createAssetPackage(urls) {
     archive.pipe(stream);
 
     const promises = urls.map(async item => {
-      const { url, baseUrl, base64Url } = item;
+      const { url, baseUrl } = item;
       const isExternalUrl = /^https?:/.test(url || '');
       if (!HAPPO_DOWNLOAD_ALL && isExternalUrl) {
         return;
@@ -80,9 +80,13 @@ module.exports = function createAssetPackage(urls) {
         return;
       }
       seenUrls.add(name);
-      if (base64Url) {
-        const data = base64Url.split(',')[1];
-        archive.append(Buffer.from(data, 'base64'), {
+      if (/\.happo-tmp\/_inlined/.test(name)) {
+        if (HAPPO_DEBUG) {
+          console.log(
+            `[HAPPO] Adding inlined asset ${name}`,
+          );
+        }
+        archive.file(name, {
           name,
           date: FILE_CREATION_DATE,
         });

--- a/task.js
+++ b/task.js
@@ -1,4 +1,8 @@
+const fs = require('fs');
+
 const nodeFetch = require('node-fetch');
+const mkdirp = require('mkdirp');
+
 const makeRequest = require('happo.io/build/makeRequest').default;
 
 const createAssetPackage = require('./src/createAssetPackage');
@@ -93,6 +97,22 @@ module.exports = {
       }
       allCssBlocks.push(block);
     });
+    return null;
+  },
+
+  async happoRegisterBase64Image({ base64Url, src }) {
+    const data = base64Url.replace(/^data:image\/png;base64,/, '');
+    const buffer = Buffer.from(data, 'base64');
+    await mkdirp('.happo-tmp/_inlined');
+    await new Promise((resolve, reject) =>
+      fs.writeFile(src.slice(1), buffer, { encoding: null }, e => {
+        if (e) {
+          reject(e);
+        } else {
+          resolve();
+        }
+      }),
+    );
     return null;
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5104,6 +5104,11 @@ mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 moment@^2.27.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"


### PR DESCRIPTION
This commit will hopefully resolve a timeout issue with
happoRegisterSnapshot (most likely) related to large snapshots with
inlined canvases. Instead of keeping the base64 url in the assets list,
we can eagerly send it in a new happoRegisterBase64Image task, store it
to disk and let the asset package simply pull in the image on disk. This
should help keep the main happoRegisterSnapshot payload smaller, which
I'm hoping will make it succeed more often. It also makes the in-memory
footprint smaller since the base64 images are discarded sooner.

For now I'm keeping a .happo-tmp folder around. I might make an effort
to automatically clean it up at some point in the future but I want to
make sure this fix is the right one first.