### PR TITLE
Don't include data uris in asset packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function getSubjectAssetUrls(subject, doc) {
       allUrls.push(...findCSSAssetUrls(style).map(url => ({ url, baseUrl })));
     }
   });
-  return allUrls;
+  return allUrls.filter(({ url }) => !url.startsWith('data:'));
 }
 
 function inlineCanvases(doc, subject, options) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,6 +79,11 @@ export default function IndexPage() {
       <div style={{ background: 'url(#shadow)' }} />
       <div className="card">
         <h1>I'm a card</h1>
+        <img
+          className="reddot"
+          src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
+          alt="Red dot"
+        />
         <i
           className="fas fa-camera"
           style={{ marginBottom: 20, fontSize: '40px' }}
@@ -146,6 +151,10 @@ export default function IndexPage() {
         }
         img {
           width: 100%;
+        }
+        img.reddot {
+          display: block;
+          width: auto;
         }
         button {
           background-color: #333;


### PR DESCRIPTION
Yesterday I was debugging issues on our happo-snap workers. For some
reason, asset packages were containing entries where the file name was a
data uri. I tracked this down to the happo-cypress module. If an image
is using a data-uri it would be included in the list of urls sent to
createAssetsPackage. If the request made to download the image resulted
in a 200 response, that content would be included in the assets package.

I fixed this issue on our workers by inspecting the zip package and only
extracting ones that we know are okay.

By filtering out data uris before we send them to the happo task, we can
get rid of this problem from the source.