### PR TITLE
Register scroll positions

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -12,7 +12,7 @@ describe('The Home Page', () => {
           const div = doc.createElement('div');
           div.innerHTML = 'Hello world!';
           return div;
-        }
+        },
       },
     });
     cy.get('body').happoScreenshot({
@@ -24,10 +24,14 @@ describe('The Home Page', () => {
           const div = doc.createElement('div');
           div.innerHTML = `Hello ${element.src}`;
           return div;
-        }
+        },
       },
     });
     cy.get('.card').happoScreenshot({ component: 'Card' });
+
+    cy.get('.scrollcontainer')
+      .scrollTo('center')
+      .happoScreenshot({ component: 'Scrollcontainer', variant: 'center' });
 
     cy.visit('/');
     cy.wait(100);

--- a/index.js
+++ b/index.js
@@ -171,6 +171,18 @@ function transformDOM({ doc, selector, transform, subject }) {
   };
 }
 
+function registerScrollPositions(doc) {
+  const elements = doc.body.querySelectorAll('*');
+  for (const node of elements) {
+    if (node.scrollTop !== 0 || node.scrollLeft !== 0) {
+      node.setAttribute(
+        'data-happo-scrollposition',
+        `${node.scrollTop},${node.scrollLeft}`,
+      );
+    }
+  }
+}
+
 Cypress.Commands.add(
   'happoScreenshot',
   { prevSubject: true },
@@ -183,6 +195,7 @@ Cypress.Commands.add(
         originalSubject[0],
         options,
       );
+      registerScrollPositions(doc);
 
       const transformCleanup = options.transformDOM
         ? transformDOM({

--- a/pages/index.js
+++ b/pages/index.js
@@ -73,6 +73,14 @@ export default function IndexPage() {
 
   return (
     <div>
+      <div className="scrollcontainer">
+        <div className="scrollinner">
+          <div style={{ backgroundColor: 'red', height: 100 }} />
+          <div style={{ backgroundColor: 'white', height: 100 }} />
+          <div style={{ backgroundColor: 'blue', height: 100 }} />
+          <div style={{ backgroundColor: 'yellow', height: 100 }} />
+        </div>
+      </div>
       <CanvasImage />
       <TaintedCanvasImage />
       <EmptyCanvasImage />
@@ -148,6 +156,16 @@ export default function IndexPage() {
           font-size: 30px;
           margin-bottom: 10px;
           font-family: 'Lobster';
+        }
+        .scrollcontainer {
+          display: block;
+          width: 100px;
+          height: 100px;
+          overflow: auto;
+        }
+        .scrollinner {
+          display: grid;
+          grid-template-columns: 100px 100px;
         }
         img {
           width: 100%;


### PR DESCRIPTION
I'm working on a change to happo workers that will make them honor a
`data-happo-scrollposition` attribute. This attribute can be used to
restore scroll positions as they were when the DOM snapshot was taken,
at screenshot time.