### PR TITLE
Fix loading images referenced from subfolder css files

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,6 +26,7 @@ class MyDocument extends Document {
           />
           <link href="/global.css" rel="stylesheet" />
           <link href="/fonts/fonts.css" rel="stylesheet" />
+          <link href="/subfolder/styles.css" rel="stylesheet" />
         </Head>
         <body>
           <Main />

--- a/pages/index.js
+++ b/pages/index.js
@@ -128,6 +128,12 @@ export default function IndexPage() {
           }}
         />
         <div
+          className="image background-from-subfolder"
+          style={{
+            paddingTop: '33%',
+          }}
+        />
+        <div
           style={{
             backgroundImage: 'url()',
           }}

--- a/public/subfolder/styles.css
+++ b/public/subfolder/styles.css
@@ -1,0 +1,3 @@
+.background-from-subfolder {
+  background: url('/storyhotel-bathroom.jpg');
+}

--- a/src/makeAbsolute.js
+++ b/src/makeAbsolute.js
@@ -5,7 +5,7 @@ module.exports = function makeAbsolute(url, baseUrl) {
     return `${baseUrl.split(':')[0]}:${url}`;
   }
   if (url.startsWith('/')) {
-    return `${baseUrl}${url}`;
+    return `${new URL(baseUrl).origin}${url}`;
   }
   if (url.startsWith('.')) {
     return new URL(`${baseUrl}${url}`).href;

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -26,6 +26,10 @@ function runTest() {
     makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/'),
     'http://goo.bar/bar/foo.png',
   );
+  assert.equal(
+    makeAbsolute('/bar/foo.png', 'http://goo.bar/foo/'),
+    'http://goo.bar/bar/foo.png',
+  );
 }
 
 runTest();


### PR DESCRIPTION
If a css file was located in a subfolder, e.g.
http://foo.bar/assets/css/styles.css, and referenced assets absolutely,
e.g. /assets/images/foo.png, they would not work. This was because we
simply appended the path to the baseUrl. To make things work, we need to
grab the image from the origin root.