### PR TITLE
Compare with latest report in dev mode

### DIFF
--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -99,9 +99,9 @@ function resolveBeforeSha(env, afterSha) {
   }
 
   if (/^dev-/.test(afterSha)) {
-    // The afterSha has been auto-generated. Don't use a base commit in this
-    // scenario
-    return undefined;
+    // The afterSha has been auto-generated. Use the special __LATEST__ sha in
+    // these cases, forcing a comparison against the latest approved report.
+    return '__LATEST__';
   }
 
   if (TRAVIS_COMMIT_RANGE) {

--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -3,7 +3,7 @@ const resolveEnvironment = require('../src/resolveEnvironment');
 
 function testDevEnv() {
   const result = resolveEnvironment({});
-  assert.equal(result.beforeSha, undefined);
+  assert.equal(result.beforeSha, '__LATEST__');
   assert.ok(/^dev-[a-z0-9]+$/.test(result.afterSha));
   assert.equal(result.link, undefined);
   assert.equal(result.message, undefined);


### PR DESCRIPTION
A new experimental feature has been added to happo.io where you can
specify` __LATEST__` as the before sha, and it will pick the latest
(approved) report to compare against. This should help people testing
out happo with cypress, as they will much quicker get a useful dashboard
and see diffs.