### PR TITLE
Add cy.happoHideDynamicElements function

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -2,6 +2,10 @@ describe('The Home Page', () => {
   it('successfully loads', () => {
     cy.visit('/');
     cy.wait(100);
+
+    cy.happoHideDynamicElements({ selectors: ['.hide-me'] });
+
+
     cy.get('body').happoScreenshot({ component: 'Full-page' });
     cy.get('body').happoScreenshot({
       component: 'Full-page',
@@ -29,11 +33,14 @@ describe('The Home Page', () => {
     });
     cy.get('.card').happoScreenshot({ component: 'Card' });
 
+    cy.get('.dynamic-text').happoScreenshot({ component: 'Dynamic text' });
+
     cy.get('.scrollcontainer')
       .scrollTo('center')
       .happoScreenshot({ component: 'Scrollcontainer', variant: 'center' });
 
     cy.visit('/');
+    cy.happoHideDynamicElements({ selectors: ['.hide-me'] });
     cy.wait(100);
     cy.get('.button').happoScreenshot({
       component: 'Button',

--- a/cypress/integration/second_page_spec.js
+++ b/cypress/integration/second_page_spec.js
@@ -1,6 +1,7 @@
 describe('A different page', () => {
   it('has happo tests', () => {
     cy.visit('/');
+    cy.happoHideDynamicElements();
     cy.get('.card').happoScreenshot({ component: 'Card', variant: 'from page' });
 
     if (Cypress.env('INTRODUCE_FAILING_ASSERTION')) {

--- a/index.js
+++ b/index.js
@@ -223,3 +223,43 @@ Cypress.Commands.add(
     });
   },
 );
+
+Cypress.Commands.add(
+  'happoHideDynamicElements',
+  (options = {}) => {
+    const {
+      defaultMatchers = [
+        /[0-9]+\sdays?\sago/,
+        /[0-9]+\sminutes?\sago/,
+        /[0-9]{1,2}:[0-9]{2}/,
+      ],
+      matchers = [],
+      defaultSelectors = ['time'],
+      selectors = [],
+    } = options;
+    const allMatchers = defaultMatchers.concat(matchers);
+    const allSelectors = defaultSelectors.concat(selectors);
+    cy.document().then(doc => {
+      const elementsToHide = [];
+      doc.body.querySelectorAll('*').forEach(e => {
+        if (e.firstElementChild) {
+          return; // this is not a leaf element
+        }
+        const text = e.textContent;
+        if (allMatchers.some(regex => regex.test(text))) {
+          elementsToHide.push(e);
+        }
+      });
+
+      for (const selector of allSelectors) {
+        doc.body.querySelectorAll(selector).forEach(e => {
+          elementsToHide.push(e);
+        });
+      }
+      for (const e of elementsToHide) {
+        console.log('Hiding', e);
+        e.setAttribute('data-happo-hide', 'true');
+      }
+    });
+  },
+);

--- a/pages/index.js
+++ b/pages/index.js
@@ -85,6 +85,31 @@ export default function IndexPage() {
       <TaintedCanvasImage />
       <EmptyCanvasImage />
       <div style={{ background: 'url(#shadow)' }} />
+      <div
+        className="dynamic-text"
+        style={{ border: '1px solid gray', padding: 10, marginBottom: 20 }}
+      >
+        <h3>Hello</h3>
+        <p>
+          Created <span>5 days ago</span> by Tom Dooner. Updated
+          <i>
+            13 minutes ago
+          </i>
+          .
+        </p>
+        <p>
+          The time is now <span>2:54pm</span>. One minute ago was <i>2:53 PM</i>
+          .
+        </p>
+        <p>
+          In Sweden however, it's <time>54 minutes past 14</time>.
+        </p>
+
+        <p>
+          Here's some content that you can{' '}
+          <b className="hide-me">manually hide</b>.
+        </p>
+      </div>
       <div className="card">
         <h1>I'm a card</h1>
         <img


### PR DESCRIPTION
This function can be used to hide certain elements that are known to
cause spurious diffs. The defaults include:

- Leaf elements with "time ago" text, e.g. "12 days ago", "3 minutes
  ago".
- <time> elements

You can append selectors via a `selectors` option and matchers (regexes)
with `matchers`.