### PR TITLE
Fix resolving assets referenced with ./

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -139,6 +139,10 @@ export default function IndexPage() {
           className="image"
           src="http://localhost:7654/storyhotel-small.jpg?foobar=ignore"
         />
+        <img
+          className="image"
+          src="./storyhotel-small.jpg"
+        />
         <div
           className="image"
           style={{

--- a/src/makeAbsolute.js
+++ b/src/makeAbsolute.js
@@ -8,7 +8,12 @@ module.exports = function makeAbsolute(url, baseUrl) {
     return `${new URL(baseUrl).origin}${url}`;
   }
   if (url.startsWith('.')) {
-    return new URL(`${baseUrl}${url}`).href;
+    const parts = [baseUrl];
+    if (!/\/$/.test(baseUrl)) {
+      parts.push('/');
+    }
+    parts.push(url);
+    return new URL(parts.join('')).href;
   }
   if (/^https?:/.test(url)) {
     return url;

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -31,7 +31,7 @@ function runTest() {
     'http://goo.bar/bar/foo.png',
   );
   assert.equal(
-    makeAbsolute('./foo.png', 'http://goo.bar/'),
+    makeAbsolute('./foo.png', 'http://goo.bar'),
     'http://goo.bar/foo.png',
   );
 }


### PR DESCRIPTION
I got a report from a customer who had updated to 1.12.1 where it would
crash trying to resolve an asset referenced via ./asset.png. Turns out
we didn't handle this case well.