### PR TITLE
Add support for dynamic targets

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -60,6 +60,7 @@ describe('The Home Page', () => {
     });
     cy.get('.card').happoScreenshot({
       component: 'Card',
+      variant: 'firefox-only',
       targets: [
         { name: 'firefoxSmall', browser: 'firefox', viewport: '400x800' },
       ],

--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -53,7 +53,16 @@ describe('The Home Page', () => {
     cy.get('.button').happoScreenshot({
       component: 'Button',
       variant: 'default',
-      targets: ['chromeSmall'],
+      targets: [
+        'chromeSmall',
+        { name: 'firefoxSmall', browser: 'firefox', viewport: '400x800' },
+      ],
+    });
+    cy.get('.card').happoScreenshot({
+      component: 'Card',
+      targets: [
+        { name: 'firefoxSmall', browser: 'firefox', viewport: '400x800' },
+      ],
     });
 
     cy.get('.images').happoScreenshot({

--- a/task.js
+++ b/task.js
@@ -78,6 +78,12 @@ function dedupeVariant(component, variant) {
 
 function handleDynamicTargets(targets) {
   const result = [];
+  if (typeof targets === 'undefined') {
+    // return non-dynamic targets from .happo.js
+    return Object.keys(happoConfig.targets).filter(
+      targetName => !happoConfig.targets[targetName].__dynamic,
+    );
+  }
   for (const target of targets) {
     if (typeof target === 'string') {
       result.push(target);
@@ -96,6 +102,7 @@ function handleDynamicTargets(targets) {
           target.browser,
           target,
         );
+        happoConfig.targets[target.name].__dynamic = true;
       }
       result.push(target.name);
     }
@@ -117,7 +124,7 @@ module.exports = {
     }
     const variant = dedupeVariant(component, rawVariant);
     snapshotAssetUrls.push(...assetUrls);
-    const targets = rawTargets ? handleDynamicTargets(rawTargets) : undefined;
+    const targets = handleDynamicTargets(rawTargets);
     snapshots.push({ html, component, variant, targets });
     cssBlocks.forEach(block => {
       if (allCssBlocks.some(b => b.key === block.key)) {
@@ -149,7 +156,8 @@ module.exports = {
     allCssBlocks = [];
     snapshotAssetUrls = [];
     if (!(HAPPO_CYPRESS_PORT || HAPPO_ENABLED)) {
-      console.log(`
+      console.log(
+        `
 [HAPPO] Happo is disabled. Here's how to enable it:
   - Use the \`happo-cypress\` wrapper when running \`cypress run\`.
   - Set \`HAPPO_ENABLED=true\` when running \`cypress open\`.
@@ -157,7 +165,8 @@ module.exports = {
 Docs:
   https://docs.happo.io/docs/cypress#usage-with-cypress-run
   https://docs.happo.io/docs/cypress#usage-with-cypress-open
-      `.trim());
+      `.trim(),
+      );
       return null;
     }
     happoConfig = await loadHappoConfig();


### PR DESCRIPTION
To make it easier to map the Happo browser targets to the viewports used
in the Cypress tests, we're making it possible to inject Happo targets
at runtime.

We're piggy-backing on the `targets` option here. If the target is a
string, use as before (limiting the screenshot to that target). If it is
an object, we merge it with the current .happo.js targets, then limit to
the new target.

Being able to dynamically add targets at runtime will make the Cypress
run better coupled to the Happo screenshots, and there's less risk for
them getting out of sync. Often times, dynamic targets will be
constructed automatically from Cypress runtime properties.