### PR TITLE
Add example of a big canvas

### DIFF
--- a/cypress/integration/bigcanvas_spec.js
+++ b/cypress/integration/bigcanvas_spec.js
@@ -1,0 +1,9 @@
+describe('Big canvas', () => {
+  it('has screenshots', () => {
+    cy.visit('/big-canvas');
+    cy.get('body').happoScreenshot({
+      component: 'Big canvas',
+      variant: 'default',
+    });
+  });
+});

--- a/pages/big-canvas.js
+++ b/pages/big-canvas.js
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function BigCanvasPage() {
+  const ref = useRef();
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    const ctx = ref.current.getContext('2d');
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0);
+      setLoaded(true);
+    };
+    img.src = '/storyhotel-breakfast.jpg';
+  });
+
+  return (
+    <div>
+      <canvas
+        className={loaded ? 'canvas-loaded' : ''}
+        ref={ref}
+        width="2000"
+        height="1333"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
We're seeing the happoRegisterBase64Image task time out for an
account. Their canvases are quite big, so I suspect there's a oom issue
of some sort here. Going to add a large canvas to our test suite to see
if it causes CI to fail the same way for us.