### PR TITLE
Chunk up saving the base64 image

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "archiver": "^3.1.1",
+    "base64-stream": "^1.0.0",
     "crypto-js": "^4.0.0",
     "https-proxy-agent": "^5.0.0",
     "mkdirp": "^1.0.4",

--- a/src/chunked.js
+++ b/src/chunked.js
@@ -1,0 +1,13 @@
+module.exports = function chunked(string, charactersPerChunk) {
+  if (string.length < charactersPerChunk) {
+    // micro-optimization for small lists
+    return [string];
+  }
+  const chunks = [];
+  let i = 0;
+  while (i < string.length) {
+    chunks.push(string.slice(i, (i += charactersPerChunk)));
+  }
+
+  return chunks;
+};

--- a/src/convertBase64FileToReal.js
+++ b/src/convertBase64FileToReal.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+const { Base64Decode } = require('base64-stream');
+
+module.exports = async function convertBase64FileToReal(filenameB64, filename) {
+  const readStream = fs.createReadStream(filenameB64);
+  const outStream = fs.createWriteStream(filename, { encoding: null });
+  const readyPromise = new Promise((resolve, reject) => {
+    outStream.on('finish', resolve);
+    outStream.on('error', reject);
+  });
+  readStream.pipe(new Base64Decode()).pipe(outStream);
+  await readyPromise;
+  await new Promise((resolve, reject) =>
+    fs.unlink(filenameB64, e => {
+      if (e) {
+        reject(e);
+      } else {
+        resolve();
+      }
+    }),
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1723,6 +1723,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64-stream/-/base64-stream-1.0.0.tgz#157ae00bc7888695e884e1fcc51c551fdfa8a1fa"
+  integrity sha512-BQQZftaO48FcE1Kof9CmXMFaAdqkcNorgc8CxesZv9nMbbTF1EFyQe89UOuh//QMmdtfUDXyO8rgUalemL5ODA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.npmjs.org/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"


### PR DESCRIPTION
The total size of the base64 package sent to the
happoRegisterBase64Image can be quite large, and we're seeing occasional
task timeouts (most likely because the task process runs out of memory
and exits). To mitigate this, I'm sending the base64 image in chunks.
Each chunk is appended to a file in the file system, and as a last step
the base64 file is converted to a real file (using streams to prevent
reading large things into memory).