### PR TITLE
Fix resolving relative assets in non-root documents

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,17 @@ module.exports = {
   },
 };
 
+function getBaseUrlWithPath(doc) {
+  return doc.location.href.slice(0, doc.location.href.lastIndexOf('/') + 1);
+}
+
 function extractCSSBlocks({ doc }) {
   const blocks = [];
   const styleElements = doc.querySelectorAll(
     'style,link[rel="stylesheet"][href]',
   );
-  const baseUrl = doc.location.origin;
+  const baseUrl = getBaseUrlWithPath(doc);
+
   styleElements.forEach(element => {
     if (element.tagName === 'LINK') {
       // <link href>
@@ -59,7 +64,7 @@ function getSubjectAssetUrls(subject, doc) {
   const allElements = [subject].concat(
     Array.from(subject.querySelectorAll('*')),
   );
-  const baseUrl = doc.location.origin;
+  const baseUrl = getBaseUrlWithPath(doc);
   allElements.forEach(element => {
     if (element.tagName === 'SCRIPT') {
       // skip script elements

--- a/src/makeAbsolute.js
+++ b/src/makeAbsolute.js
@@ -7,16 +7,14 @@ module.exports = function makeAbsolute(url, baseUrl) {
   if (url.startsWith('/')) {
     return `${new URL(baseUrl).origin}${url}`;
   }
-  if (url.startsWith('.')) {
-    const parts = [baseUrl];
-    if (!/\/$/.test(baseUrl)) {
-      parts.push('/');
-    }
-    parts.push(url);
-    return new URL(parts.join('')).href;
-  }
   if (/^https?:/.test(url)) {
     return url;
   }
-  return `${baseUrl}/${url}`;
+
+  const parts = [baseUrl];
+  if (!/\/$/.test(baseUrl)) {
+    parts.push('/');
+  }
+  parts.push(url);
+  return new URL(parts.join('')).href;
 };

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -34,6 +34,10 @@ function runTest() {
     makeAbsolute('./foo.png', 'http://goo.bar'),
     'http://goo.bar/foo.png',
   );
+  assert.equal(
+    makeAbsolute('foo/bar/baz.png', 'http://goo.bar/car/'),
+    'http://goo.bar/car/foo/bar/baz.png',
+  );
 }
 
 runTest();


### PR DESCRIPTION
Our previous use of doc.location.origin as the base url caused issues
when you were on a page with a path, e.g.

http://host.domain/foo/index.html

and had a relative path to a stylesheet, e.g.

themes/bar/styles.css

We ended up resolving the path to the css as
http://host.domain/themes/bar/styles.css, which is incorrect -- we need
the path involved in the base url as well.