### PR TITLE
Resolve styles from right baseUrl in SPA

### DIFF
--- a/cypress/integration/spa_spec.js
+++ b/cypress/integration/spa_spec.js
@@ -1,0 +1,7 @@
+describe('Single page application', () => {
+  it('has happo tests', () => {
+    cy.visit('/hello');
+    cy.contains('Click me').click();
+    cy.get('h1').happoScreenshot({ component: 'Header', variant: 'red' });
+  });
+});

--- a/pages/hello.js
+++ b/pages/hello.js
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import React, { useEffect } from 'react';
+
+export default function InitialHelloPage() {
+  useEffect(() => {
+    const el = document.createElement('link');
+    el.setAttribute('rel', 'stylesheet');
+    el.setAttribute('href', 'subfolder/hello.css');
+    document.head.appendChild(el);
+  }, []);
+
+  return (
+    <div>
+      <Link href="/subfolder/hello"><a>Click me</a></Link>
+    </div>
+  );
+}

--- a/pages/subfolder/hello.js
+++ b/pages/subfolder/hello.js
@@ -1,0 +1,9 @@
+import React, { useEffect } from 'react';
+
+export default function HelloPage() {
+  return (
+    <div>
+      <h1>Hello world. I'm red.</h1>
+    </div>
+  );
+}

--- a/public/subfolder/hello.css
+++ b/public/subfolder/hello.css
@@ -1,0 +1,7 @@
+h1 {
+  color: red;
+  font-size: 22px;
+  font-weight: bold;
+}
+
+


### PR DESCRIPTION
In a single-page-application, the document you land on will dynamically
change its location with history.pushState. This leads to a problem when
downloading relative assets, if the original document is in a different
sub path than the tests. Take this example:

Start page is loaded at url "/".
Link "admin" is clicked.
Page "/admin/start" is loaded.
A happo screenshot is taken.

If any css was added in the initial page load, and it has a relative
path (e.g. "styles.css", or "./styles.css"), the screenshot will be
missing those styles. To fix this, we need to "remember" the baseUrl for
style elements (including <link>). We do this by subscribing to the
"window:load" event from Cypress and setting the baseUrl as a property
on all css elements found right at the start.

This isn't a fool-proof solution. There can still be cases where the
style element isn't present on initial page load, but is added
dynamically on the start page after it has been loaded. Then, the
baseUrl property wouldn't be set and Happo would look for the css file
relative to e.g. /admin/. I can live with this however as I think the
current fix will cover 99% of all cases. Plus, using relative urls to
style sheets isn't too common.