### PR TITLE
Find document from subject element

### DIFF
--- a/cypress/integration/iframe_spec.js
+++ b/cypress/integration/iframe_spec.js
@@ -1,0 +1,13 @@
+describe('iframe tests', () => {
+  it('has happo tests', () => {
+    cy.visit('/iframed');
+    cy.getIframe().happoScreenshot({
+      component: 'Start page',
+      variant: 'iframed',
+    });
+    cy.getIframe().find('.button').happoScreenshot({
+      component: 'Button',
+      variant: 'from iframe',
+    });
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,3 +29,10 @@ import { configure } from '../../';
 
 configure({ responsiveInlinedCanvases: false });
 
+Cypress.Commands.add('getIframe', () => {
+  return cy
+    .get('iframe')
+    .its('0.contentDocument')
+    .its('body')
+    .then(cy.wrap);
+});

--- a/index.js
+++ b/index.js
@@ -216,38 +216,38 @@ Cypress.Commands.add(
   (originalSubject, options = {}) => {
     const component = options.component || cy.state('runnable').fullTitle();
     const variant = options.variant || 'default';
-    cy.document().then(doc => {
-      const { subject, cleanup: canvasCleanup } = inlineCanvases(
-        doc,
-        originalSubject[0],
-        options,
-      );
-      registerScrollPositions(doc);
 
-      const transformCleanup = options.transformDOM
-        ? transformDOM({
-            doc,
-            subject,
-            ...options.transformDOM,
-          })
-        : undefined;
+    const doc = originalSubject[0].ownerDocument;
+    const { subject, cleanup: canvasCleanup } = inlineCanvases(
+      doc,
+      originalSubject[0],
+      options,
+    );
+    registerScrollPositions(doc);
 
-      const html = subject.outerHTML;
-      const assetUrls = getSubjectAssetUrls(subject, doc);
-      const cssBlocks = extractCSSBlocks({ doc });
-      cy.task('happoRegisterSnapshot', {
-        html,
-        cssBlocks,
-        assetUrls,
-        component,
-        variant,
-        targets: options.targets,
-      });
-      if (transformCleanup) {
-        transformCleanup();
-      }
-      canvasCleanup();
+    const transformCleanup = options.transformDOM
+      ? transformDOM({
+          doc,
+          subject,
+          ...options.transformDOM,
+        })
+      : undefined;
+
+    const html = subject.outerHTML;
+    const assetUrls = getSubjectAssetUrls(subject, doc);
+    const cssBlocks = extractCSSBlocks({ doc });
+    cy.task('happoRegisterSnapshot', {
+      html,
+      cssBlocks,
+      assetUrls,
+      component,
+      variant,
+      targets: options.targets,
     });
+    if (transformCleanup) {
+      transformCleanup();
+    }
+    canvasCleanup();
   },
 );
 

--- a/pages/iframed.js
+++ b/pages/iframed.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function IframedPage() {
+  return (
+    <div>
+      <h1>Iframed content</h1>
+      <iframe src="/" width="400" height="400" />
+    </div>
+  );
+}


### PR DESCRIPTION
This commit fixes an issue where taking a screenshot of an iframe body
would result in no styles being present in the screenshot. This is
because we were assuming that all elements and styles were present in
the root cypress document. By grabbing the document relative to the
element we're working with, we can make screenshots of iframe content
look better.

Please note that this doesn't fix the issue where taking a screenshot of
some element that wraps an iframe results in the iframe being empty.
This commit will only make it so that you can dive into an iframe and
select elements (including <body>) inside.