### PR TITLE
Remove script tags when recording html

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,6 +233,9 @@ Cypress.Commands.add(
         })
       : undefined;
 
+    subject.querySelectorAll('script').forEach(scriptEl => {
+      scriptEl.parentNode.removeChild(scriptEl);
+    });
     const html = subject.outerHTML;
     const assetUrls = getSubjectAssetUrls(subject, doc);
     const cssBlocks = extractCSSBlocks({ doc });


### PR DESCRIPTION
I was debugging a test suite and noticed that some javascript executed
on Happo workers when injecting the html into the page. It turns out
that there were script tags in the recorded html that referenced
external scripts (on a CDN). We don't want to double-execute these
scripts. Since scripts are executed once when running the test suite,
having them execute again will only lead to confusion.