### PR TITLE
Inject classes from <html> element before screenshot

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,14 @@ Cypress.Commands.add(
     subject.querySelectorAll('script').forEach(scriptEl => {
       scriptEl.parentNode.removeChild(scriptEl);
     });
+    const htmlElementClass = subject.ownerDocument.documentElement.getAttribute('class');
+    if (htmlElementClass) {
+      const el = document.createElement('script');
+      el.innerHTML = `
+        document.documentElement.setAttribute('class', ${JSON.stringify(htmlElementClass)});
+      `;
+      subject.appendChild(el);
+    }
     const html = subject.outerHTML;
     const assetUrls = getSubjectAssetUrls(subject, doc);
     const cssBlocks = extractCSSBlocks({ doc });

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className="html-rocks">
         <Head>
           <link
             href="https://fonts.googleapis.com/css?family=Lobster&display=swap"

--- a/public/global.css
+++ b/public/global.css
@@ -6,6 +6,6 @@ body {
   display: block !important;
 }
 
-.canvas {
+.html-rocks .canvas {
   border: 2px solid red;
 }


### PR DESCRIPTION
I've seen classes on the `html` element affect styling a few times now,
and I decided to do something about this. By grabbing the html classes
at happoScreenshot time, and then injecting them at screenshot time, we
can get better style matching with the "real" website.

An example of a style I'm testing this on is a website with a
`fonts-loaded` class set. This class affects what fonts are shown in the
UI.