### PR TITLE
Send html and body attributes in payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,14 @@ function registerScrollPositions(doc) {
   }
 }
 
+function extractAttributes(el) {
+  const result = {};
+  [...el.attributes].forEach(item => {
+    result[item.name] = item.value;
+  });
+  return result;
+}
+
 Cypress.Commands.add(
   'happoScreenshot',
   { prevSubject: true },
@@ -245,6 +253,8 @@ Cypress.Commands.add(
       assetUrls,
       component,
       variant,
+      htmlElementAttrs: extractAttributes(subject.ownerDocument.documentElement),
+      bodyElementAttrs: extractAttributes(subject.ownerDocument.body),
       targets: options.targets,
     });
     if (transformCleanup) {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang="en" className="html-wrapper">
         <Head>
           <link
             href="https://fonts.googleapis.com/css?family=Lobster&display=swap"

--- a/public/global.css
+++ b/public/global.css
@@ -6,6 +6,6 @@ body {
   display: block !important;
 }
 
-.canvas {
-  border: 2px solid red;
+.html-wrapper .canvas {
+  border: 2px solid #ff0000;
 }

--- a/task.js
+++ b/task.js
@@ -120,6 +120,8 @@ module.exports = {
     component,
     variant: rawVariant,
     targets: rawTargets,
+    htmlElementAttrs,
+    bodyElementAttrs,
   }) {
     if (!happoConfig) {
       return null;
@@ -127,7 +129,14 @@ module.exports = {
     const variant = dedupeVariant(component, rawVariant);
     snapshotAssetUrls.push(...assetUrls);
     const targets = handleDynamicTargets(rawTargets);
-    snapshots.push({ html, component, variant, targets });
+    snapshots.push({
+      html,
+      component,
+      variant,
+      targets,
+      htmlElementAttrs,
+      bodyElementAttrs,
+    });
     cssBlocks.forEach(block => {
       if (allCssBlocks.some(b => b.key === block.key)) {
         return;


### PR DESCRIPTION
I'm working on a change to happo workers which makes these attributes
come in play (get injected at render time). This will help resolve test
suites where some element depends on attributes from the html or body
element for its styling.