### PR TITLE
Send fallback shas to Happo server

### DIFF
--- a/bin/happo-cypress.js
+++ b/bin/happo-cypress.js
@@ -98,6 +98,7 @@ async function finalizeAll() {
     message,
     nonce,
     notify,
+    fallbackShas,
   } = resolveEnvironment();
   if (!nonce) {
     throw new Error('[HAPPO] Missing HAPPO_NONCE environment variable');
@@ -121,6 +122,7 @@ async function finalizeAll() {
       message,
       isAsync: true,
       notify,
+      fallbackShas,
     });
   }
 }
@@ -143,6 +145,7 @@ async function finalizeHappoReport() {
     message,
     nonce,
     notify,
+    fallbackShas,
   } = resolveEnvironment();
   const reportResult = await postAsyncReport({
     requestIds: [...allRequestIds],
@@ -169,6 +172,7 @@ async function finalizeHappoReport() {
         message,
         isAsync: true,
         notify,
+        fallbackShas,
       });
     }
     console.log(`[HAPPO] ${jobResult.url}`);


### PR DESCRIPTION
Support for fallback shas to use as the baseline was added earlier this
year for the main happo.io library [1]. But the happo-cypress library was
never updated. I just had a support issue where someone was trying to
compare using a different base branch than master, and they were getting
confusing results.

Fallback shas take precedence over Happo's default way of resolving
baseline reports from the main/default branch.

I was a little confused to see that the format for fallbackShas passed
to compareReports was expected to be "raw" and that string splitting
happened late. Not going to worry about that right now, but might be
worth making the interface a little nicer.
https://github.com/happo/happo.io/blob/8bf7980a69572066fec6daf81c0a1249d50e6051/src/commands/compareReports.js#L27

[1] https://github.com/happo/happo.io/releases/tag/v6.6.0