### PR TITLE
Resolve fallback shas from before beforeSha

### DIFF
--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -193,7 +193,7 @@ function resolveFallbackShas(env, beforeSha) {
       '--format=%H',
       '--first-parent',
       `--max-count=${HAPPO_FALLBACK_SHAS_COUNT}`,
-      beforeSha,
+      `${beforeSha}^`,
     ],
     {
       encoding: 'utf-8',

--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -99,12 +99,23 @@ function testTravisEnv() {
     TRAVIS_PULL_REQUEST: undefined,
     TRAVIS_COMMIT_RANGE: undefined,
     TRAVIS_COMMIT: '4521c1411c5c0ad19fd72fa31b12363ab54d5eab',
+    HAPPO_FALLBACK_SHAS_COUNT: '5',
   });
 
   assert.equal(result.afterSha, '4521c1411c5c0ad19fd72fa31b12363ab54d5eab');
   assert.equal(
     result.link,
     'http://git.hub/owner/repo/commit/4521c1411c5c0ad19fd72fa31b12363ab54d5eab',
+  );
+  assert.equal(
+    result.fallbackShas,
+    `
+62aa0e29b68d0d2e812ad21064b22bf627400ab8
+c9698e46a96eb1c695c9ef69e478e78703701f6b
+0520795dc6d5f02219c153e9502c3510ead2e1c0
+c7729934ee346351747c7af7f4ed570ce6ba3397
+bdac2595db20ad2a6bf335b59510aa771125526a
+`.trimStart(),
   );
   assert.ok(result.message !== undefined);
 }


### PR DESCRIPTION
Previously, we were sending fallbacks that included the current
beforeSha commit. This could potentially work but it wasn't how I
intended to do things initially. Plus, that's not how the happo.io
library does it (which is what I tried to mimic):
https://github.com/happo/happo.io/blob/8bf7980a69572066fec6daf81c0a1249d50e6051/bin/happo-ci#L25