### PR TITLE
Create snap-requests serially

### DIFF
--- a/task.js
+++ b/task.js
@@ -252,34 +252,33 @@ Docs:
       }
     }
     const allRequestIds = [];
-    await Promise.all(
-      Object.keys(happoConfig.targets).map(async name => {
-        if (HAPPO_DEBUG) {
-          console.log(`[HAPPO] Sending snap-request(s) for target=${name}`);
-        }
-        const snapshotsForTarget = snapshots.filter(
-          ({ targets }) => !targets || targets.includes(name),
+    for (const name of Object.keys(happoConfig.targets)) {
+      if (HAPPO_DEBUG) {
+        console.log(`[HAPPO] Sending snap-request(s) for target=${name}`);
+      }
+      const snapshotsForTarget = snapshots.filter(
+        ({ targets }) => !targets || targets.includes(name),
+      );
+      const requestIds = await happoConfig.targets[name].execute({
+        targetName: name,
+        asyncResults: true,
+        endpoint: happoConfig.endpoint,
+        globalCSS,
+        assetsPackage: assetsRes.path,
+        snapPayloads: snapshotsForTarget,
+        apiKey: happoConfig.apiKey,
+        apiSecret: happoConfig.apiSecret,
+      });
+      if (HAPPO_DEBUG) {
+        console.log(
+          `[HAPPO] Snap-request(s) for target=${name} created with ID(s)=${requestIds.join(
+            ',',
+          )}`,
         );
-        const requestIds = await happoConfig.targets[name].execute({
-          targetName: name,
-          asyncResults: true,
-          endpoint: happoConfig.endpoint,
-          globalCSS,
-          assetsPackage: assetsRes.path,
-          snapPayloads: snapshotsForTarget,
-          apiKey: happoConfig.apiKey,
-          apiSecret: happoConfig.apiSecret,
-        });
-        if (HAPPO_DEBUG) {
-          console.log(
-            `[HAPPO] Snap-request(s) for target=${name} created with ID(s)=${requestIds.join(
-              ',',
-            )}`,
-          );
-        }
-        allRequestIds.push(...requestIds);
-      }),
-    );
+      }
+      allRequestIds.push(...requestIds);
+    }
+
     if (HAPPO_CYPRESS_PORT) {
       // We're running with `happo-cypress --`
       const fetchRes = await nodeFetch(


### PR DESCRIPTION
I've been chasing a bug with the following error for a while now:

`cy.task('happoTeardown')` timed out after waiting `60000ms`.

It's been happening to a few customers, but never with a consistent
repro case. I finally saw it happen locally and got some debug logs I
could look at, and from what I can see it looks like the node process
that happoTeardown runs in simply stalls/crashes silently:

[HAPPO] Done uploading assets package, got { path: 'a/8/bfe0333567ebb1f8ebbe1485cb18c7dd.zip' }
[HAPPO] Sending snap-request(s) for target=chrome-large
[HAPPO] Sending snap-request(s) for target=firefox-large
[HAPPO] Sending snap-request(s) for target=safari-large
[HAPPO] Sending snap-request(s) for target=edge-large
[HAPPO] Sending snap-request(s) for target=ie-large
[HAPPO] Sending snap-request(s) for target=ios-safari
[HAPPO] Sending snap-request(s) for target=ipad-safari
[HAPPO] Snap-request(s) for target=safari-large created with ID(s)=1758301
[HAPPO] Snap-request(s) for target=ie-large created with ID(s)=1758302
[HAPPO] Snap-request(s) for target=chrome-large created with ID(s)=1758303
[HAPPO] Snap-request(s) for target=edge-large created with ID(s)=1758304
[HAPPO] Snap-request(s) for target=ios-safari created with ID(s)=1758305
    1) "after all" hook for "works"

  0 passing (1m)
  1 failing

  1) Signing up for a trial account
       "after all" hook for "works":
     CypressError: `cy.task('happoTeardown')` timed out after waiting `60000ms`.

In this case, 7 snap-requests are attempted to be created, but only 5
are successful. On the server I can see these 5 requests in the logs,
but the 2 failing ones are nowhere to be seen, no trace. This leads me
to think that the process simply dies because of high resource usage
(memory perhaps?). Since all snap-requests are created in parallell,
there may be race conditions causing high usage of something, causing
the process to fail. I'm going to try changing things to run serially
instead, hopefully that will make the problem go away. Of course, this
leads to slightly longer wait times, but I'm not too concerned. The
average snap-request response takes a few hundred ms to respond so we're
talking maybe a second longer run times on average test suites.