### PR TITLE
Remove retried snapshots before sending to happo.io

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,4 +26,5 @@ jobs:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RETRY_FAIL_ONCE: true
 

--- a/cypress/integration/second_page_spec.js
+++ b/cypress/integration/second_page_spec.js
@@ -7,5 +7,11 @@ describe('A different page', () => {
     if (Cypress.env('INTRODUCE_FAILING_ASSERTION')) {
       cy.get('body').should('have.class', 'nope');
     }
+    if (Cypress.env('RETRY_FAIL_ONCE')) {
+      if (!global.hasFailedOnce) {
+        cy.get('body').should('have.class', 'nope');
+        global.hasFailedOnce = true;
+      }
+    }
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,6 +1,14 @@
 const happoTask = require('../../task');
 
-module.exports = (on) => {
-  on('task', happoTask);
-  on('after:screenshot', happoTask.handleAfterScreenshot);
+module.exports = (on, config) => {
+  happoTask.register(on);
+
+  if (process.env.CYPRESS_RETRY_FAIL_ONCE) {
+    console.log('Adjusting config to allow one retry');
+    config.retries = {
+      runMode: 1,
+    };
+  }
+
+  return config;
 };

--- a/index.js
+++ b/index.js
@@ -23,10 +23,6 @@ before(() => {
   });
 });
 
-after(() => {
-  cy.task('happoTeardown');
-});
-
 const COMMENT_PATTERN = /^\/\*.+\*\/$/;
 
 let config = {
@@ -275,6 +271,7 @@ Cypress.Commands.add(
     const assetUrls = getSubjectAssetUrls(subject, doc);
     const cssBlocks = extractCSSBlocks({ doc });
     cy.task('happoRegisterSnapshot', {
+      timestamp: Date.now(),
       html,
       cssBlocks,
       assetUrls,

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ function getBaseUrlWithPath(doc) {
 }
 
 before(() => {
-  cy.task('happoInit');
   cy.on('window:load', window => {
     const styleElements = window.document.querySelectorAll(
       CSS_ELEMENTS_SELECTOR,

--- a/task.js
+++ b/task.js
@@ -225,6 +225,13 @@ async function processSnapRequestIds(allRequestIds) {
 }
 
 function removeSnapshotsMadeBetween({ start, end }) {
+  if (HAPPO_DEBUG) {
+    console.log(
+      `[HAPPO] Removing snapshots made between ${new Date(
+        start,
+      )} and ${new Date(end)}`,
+    );
+  }
   snapshots = snapshots.filter(({ timestamp }) => {
     if (!timestamp) {
       return true;
@@ -244,6 +251,9 @@ const task = {
   async handleAfterSpec(spec, results) {
     if (!happoConfig) {
       return;
+    }
+    if (HAPPO_DEBUG) {
+      console.log('[HAPPO] Running after:spec hook');
     }
     for (const test of results.tests) {
       const wasRetried =
@@ -391,6 +401,9 @@ Docs:
       );
       return null;
     }
+    if (HAPPO_DEBUG) {
+      console.log('[HAPPO] Running happoInit');
+    }
     happoConfig = await loadHappoConfig();
     if (happoConfig && !task.isRegisteredCorrectly) {
       throw new Error(`happo-cypress hasn't been registered correctly. Make sure you call \`happoTask.register\` when you register the plugin:
@@ -408,6 +421,9 @@ Docs:
   async happoTeardown() {
     if (!happoConfig) {
       return null;
+    }
+    if (HAPPO_DEBUG) {
+      console.log('[HAPPO] Running happoTeardown');
     }
     if (localSnapshots.length) {
       await processSnapRequestIds([await uploadLocalSnapshots()]);

--- a/task.js
+++ b/task.js
@@ -245,6 +245,7 @@ const task = {
     on('task', task);
     on('after:screenshot', task.handleAfterScreenshot);
     on('after:spec', task.handleAfterSpec);
+    on('before:spec', task.happoInit);
     task.isRegisteredCorrectly = true;
   },
 
@@ -260,7 +261,7 @@ const task = {
         test.attempts.some(t => t.state === 'failed') &&
         test.attempts[test.attempts.length - 1].state === 'passed';
       if (!wasRetried) {
-        return;
+        continue;
       }
       for (const attempt of test.attempts) {
         if (attempt.state === 'failed') {


### PR DESCRIPTION
If a test is automatically retried, happo would duplicate snapshots that
were part of the retry and add a counter suffix to the variant name,
e.g. "foo-bar-1".

To fix this, I've made us listen to the after:spec event, then inspect
each test to look for failed attempts. If a failed attempt is found, we
delete all snapshots made during the duration of the failed attempt. I'm
making the assumption that timestamps will be in sync between the
browser process and the background node process. This could be
dangerous, but I couldn't find a better alternative to associate
snapshots with a test attempt.

Because of the added after:snapshot event handler, I'm changing the
initialization process:

happoTask.register(on)

This is a breaking change, so in order to help people upgrading without
updating config, I'm adding an assertion and an error message if we
detect that we haven't registered correctly.