### PR TITLE
Move happo-e2e to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "happo.io": "^6.4.0",
     "next": "^12.0.8",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "happo-e2e": "^1.4.2"
   },
-  "dependencies": {
-    "happo-e2e": "1.4.2-rc.1"
+  "peerDependencies": {
+    "happo-e2e": "^1.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,10 +1365,10 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-happo-e2e@1.4.2-rc.1:
-  version "1.4.2-rc.1"
-  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.4.2-rc.1.tgz#9e3128ee3b3a71e997750b7b374e674198264043"
-  integrity sha512-afbNFpaJI5a7By9ww4C83+M1pCBT5OY9Wr4GDgetodQV+1+ek+R0cehEseHNHBIeHp5qPa4LQktZbfYLexUbkw==
+happo-e2e@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.4.2.tgz#e562896ff34e0482abd26d3ee1bcf167e39b551f"
+  integrity sha512-aHKzbMgTAjryWJ8Qv2Bzk3dBWo1AUwFpruaS4YZab03sKzRaeB4NdPAR77HhyxxrOYqpuheZjJfoNJ7CxmUUSA==
   dependencies:
     archiver "^5.3.0"
     base64-stream "^1.0.0"


### PR DESCRIPTION
The docs informs users to install happo-e2e separately, so having happo-e2e listed in dependencies will most likely mean that two versions will get installed.

Moving to a peer dependency means we can make updates to happo-e2e separately from this package.