### PR TITLE
Add support for `includeAllElements: true` option for happoScreenshot

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -33,6 +33,10 @@ describe('The Home Page', () => {
       },
     });
     cy.get('.card').happoScreenshot({ component: 'Card' });
+    cy.get('.card,.button').happoScreenshot({
+      includeAllElements: true,
+      component: 'Card + Button',
+    });
 
     cy.happoHideDynamicElements({ selectors: ['.hide-me'] });
     cy.get('.dynamic-text').happoScreenshot({

--- a/index.js
+++ b/index.js
@@ -56,10 +56,11 @@ Cypress.Commands.add(
         ? options.responsiveInlinedCanvases
         : config.responsiveInlinedCanvases;
 
-
     const domSnapshot = takeDOMSnapshot({
       doc,
-      element: originalSubject[0],
+      element: options.includeAllElements
+        ? originalSubject
+        : originalSubject[0],
       responsiveInlinedCanvases,
       transformDOM: options.transformDOM,
       handleBase64Image: ({ src, base64Url }) => {
@@ -76,7 +77,7 @@ Cypress.Commands.add(
             isLast,
           });
         }
-      }
+      },
     });
 
     cy.task('happoRegisterSnapshot', {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "devDependencies": {
     "cypress": "^10.1.0",
     "eslint": "^6.8.0",
+    "happo-e2e": "^2.2.0",
     "happo.io": "^6.4.0",
     "next": "^12.0.8",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "happo-e2e": "^1.4.2"
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
     "happo-e2e": ">= 1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,10 +1365,10 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-happo-e2e@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.4.2.tgz#e562896ff34e0482abd26d3ee1bcf167e39b551f"
-  integrity sha512-aHKzbMgTAjryWJ8Qv2Bzk3dBWo1AUwFpruaS4YZab03sKzRaeB4NdPAR77HhyxxrOYqpuheZjJfoNJ7CxmUUSA==
+happo-e2e@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-2.2.0.tgz#668c5b7db22b915839d38d5e9a68c2b0156cee5b"
+  integrity sha512-R2RsStFT5DKz6nEayrH7fFM+7nKgbBe+Xycoy9WTHYbcbQVXSEIuS4PtkYD5itIKdnJ4B/s0jpznGzrMPbmD0A==
   dependencies:
     archiver "^5.3.0"
     base64-stream "^1.0.0"


### PR DESCRIPTION
This option will make the screenshot include all elements that matches the selector (the subject of the `happoScreenshot` call) when taking the DOM snapshot. Requires version happo-e2e@2.2.0 or later.