### PR TITLE
Don't add `/.next` to the resulting NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ pages
 test
 public
 cypress.json
+.next


### PR DESCRIPTION
`44M	./node_modules/happo-cypress/.next/` which is not ideal, AFAIU this app is needed only for tests.
Not sure how npm packaging works, but I suppose this PR would skip the directory.