### PR TITLE
Allow snapshot strategy to be configured

### DIFF
--- a/cypress/integration/home_page_spec.js
+++ b/cypress/integration/home_page_spec.js
@@ -122,5 +122,18 @@ describe('The Home Page', () => {
       variant: 'empty',
       log: false,
     });
+
+    cy.get('#stretch-to-parent', { log: false }).happoScreenshot({
+      component: 'Stretch to parent',
+      variant: 'snapshotStrategy hoist',
+      log: false,
+      snapshotStrategy: 'hoist',
+    });
+    cy.get('#stretch-to-parent', { log: false }).happoScreenshot({
+      component: 'Stretch to parent',
+      variant: 'snapshotStrategy clip',
+      log: false,
+      snapshotStrategy: 'clip',
+    });
   });
 });

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ Cypress.Commands.add(
       includeAllElements,
       transformDOM,
       targets,
+      snapshotStrategy = 'hoist',
       ...otherOptions
     } = options;
 
@@ -75,6 +76,7 @@ Cypress.Commands.add(
       element: includeAllElements ? originalSubject : originalSubject[0],
       responsiveInlinedCanvases: resInCan,
       transformDOM: transformDOM,
+      strategy: snapshotStrategy,
       handleBase64Image: ({ src, base64Url }) => {
         const rawBase64 = base64Url.replace(/^data:image\/png;base64,/, '');
         const chunks = chunked(rawBase64, config.canvasChunkSize);

--- a/pages/index.js
+++ b/pages/index.js
@@ -174,6 +174,14 @@ export default function IndexPage() {
           src="https://q-xx.bstatic.com/xdata/images/hotel/max1000/133065887.jpg?k=4d2f546ba33c456afeceed92d808a48de95f92c65a235c9cf399a6e2f6c67c34&o="
         />
       </div>
+
+      <div style={{ width: 200 }}>
+        I am 200px wide.
+        <div style={{ width: '100%' }} id="stretch-to-parent">
+          I stretch to 100% width of my parent, which is 200px wide.
+        </div>
+      </div>
+
       <style jsx>{`
         .card {
           max-width: 400px;


### PR DESCRIPTION
Similar to `localSnapshots: true`, we want people to be able to use the new "clip" snapshot strategy that happo-e2e has made available.

https://docs.happo.io/docs/cypress#locally-produced-images

The clip strategy means the whole dom is included in the snapshot, and happo workers will clip the screenshot based on where the `[data-happo-clip]` element is located.